### PR TITLE
fix: declare WooCommerce HPOS and cart/checkout blocks compatibility

### DIFF
--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -34,8 +34,23 @@ class Plugin {
 		$this->container = TryAura::container();
 		register_activation_hook( TRYAURA_FILE, array( Installer::class, 'activate' ) );
 		$this->define_constants();
+		add_action( 'before_woocommerce_init', array( $this, 'declare_woocommerce_compatibility' ) );
 		add_action( 'plugins_loaded', array( $this, 'load_container' ) );
 		add_action( 'init', array( $this, 'init_classes') );
+	}
+
+	/**
+	 * Declare compatibility with WooCommerce features.
+	 *
+	 * @since 1.0.3
+	 *
+	 * @return void
+	 */
+	public function declare_woocommerce_compatibility() {
+		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', TRYAURA_FILE, true );
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', TRYAURA_FILE, true );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Resolves WooCommerce admin warning about plugin incompatibility with enabled features. Plugin has no order-storage code, so HPOS declaration is safe. Cart/checkout blocks declared since plugin does not modify checkout flows.
### Closes 

* Closes https://github.com/getdokan/tryaura-pro/issues/13