### PR TITLE
feat: admin Top Bar — logo, version badges, Get Support, help menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,7 @@ The plugin uses `addFilter` / `applyFilters` / `doAction` from `@wordpress/hooks
 | `tryaura.routes` | filter | Add custom dashboard routes/pages |
 | `tryaura.recent.activity.tabs` | filter | Add activity log tabs |
 | `tryaura.chartlines` | filter | Add chart data series |
+| `tryaura.admin.help_menu_items` | filter | Add/remove/reorder Top Bar help menu items |
 
 **Frontend — Try-on modal:**
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,29 @@
+# TryAura — Ubiquitous Language
+
+A glossary of domain terms for this plugin. Keep implementation details out.
+
+## Admin chrome
+
+- **Top Bar** — The persistent plugin header rendered at the top of every TryAura
+  admin screen. Contains the plugin logo, version badges, the Get Support button,
+  and the Help Menu. Built from the StorePulse component system.
+- **Help Menu** — The dropdown opened by the "?" button in the Top Bar. Lists
+  external self-service links (Documentation, FAQ, Request a Feature, Changelog,
+  and — for Lite users only — Upgrade to Pro).
+- **Version Badge** — A plain-text (non-link) badge in the Top Bar showing an
+  installed plugin version. The **Lite badge** always shows and reads the free
+  plugin's header version; the **Pro badge** shows only when TryAura Pro is
+  active and reads the Pro plugin's header version.
+
+## Editions & platform
+
+- **Lite** — The free TryAura plugin distributed on WordPress.org.
+- **Pro** — The TryAura Pro plugin. Declares its presence to Lite via the
+  `tryaura_is_pro_exists` filter; Lite exposes this to JS as `hasPro`.
+- **StorePulse** — The product family/brand (storepulse.co) that TryAura belongs
+  to. Shared UI across StorePulse plugins comes from the **StorePulse component
+  system**, implemented as the `@wedevs/plugin-ui` package.
+- **plugin-ui** — The shared `@wedevs/plugin-ui` React component library
+  (getdokan/plugin-ui). Components render inside a `ThemeProvider` scope.
+  TryAura consumes it with default tokens: no custom theme, no dark mode, and
+  no Shadow DOM for now.

--- a/docs/adr/0001-adopt-plugin-ui-for-admin-chrome.md
+++ b/docs/adr/0001-adopt-plugin-ui-for-admin-chrome.md
@@ -1,0 +1,37 @@
+# 1. Adopt @wedevs/plugin-ui for admin chrome
+
+Date: 2026-07-22
+
+## Status
+
+Accepted
+
+## Context
+
+TryAura needed a persistent admin Top Bar (logo, version badges, Get Support,
+help menu — tryaura-pro#40/#41). TryAura already had its own small component
+set (`src/components/`) with a scoped Tailwind theme, so the bar could have
+been built in-house. But the bar is meant to be shared across StorePulse
+plugins, and wePOS — the next candidate — already builds its admin on
+`@wedevs/plugin-ui` (getdokan/plugin-ui), which ships a ready-made `TopBar`
+and `DropdownMenu` with the dismissal behaviors the spec requires.
+
+## Decision
+
+Add `@wedevs/plugin-ui` as a dependency and build the Top Bar from its
+components. Wrap the dashboard SPA in its `ThemeProvider` (the mechanism that
+creates the `.pui-root` style scope), using **default tokens only** — no
+custom accent, no dark mode, no Shadow DOM. TryAura's existing components and
+`.tryaura`-scoped styles remain untouched for everything else.
+
+## Consequences
+
+- The admin bundle carries both style systems (`.tryaura` and `.pui-root`);
+  new admin chrome should prefer plugin-ui so the in-house set can shrink
+  over time rather than grow.
+- The Top Bar's look now tracks upstream plugin-ui; visual changes can arrive
+  via dependency updates.
+- Theming (indigo accent, dark mode) is deliberately deferred; enabling it
+  later is a token override in one place, not a rebuild.
+- The same bar can be ported to wePOS and other StorePulse plugins with only
+  logo/links/data-seam differences.

--- a/inc/Admin/Admin.php
+++ b/inc/Admin/Admin.php
@@ -32,6 +32,59 @@ class Admin {
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 		add_action( 'admin_menu', array( $this, 'register_admin_page' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+
+		// Capture admin notices so the Top Bar renders first on our page.
+		add_action( 'admin_notices', array( $this, 'inject_before_notices' ), -9999 );
+		add_action( 'admin_notices', array( $this, 'inject_after_notices' ), PHP_INT_MAX );
+	}
+
+	/**
+	 * Whether the current admin screen is the TryAura page.
+	 *
+	 * @since 1.0.5
+	 *
+	 * @return bool
+	 */
+	private function is_tryaura_admin_page(): bool {
+		$screen = get_current_screen();
+
+		return $screen && 'toplevel_page_tryaura' === $screen->id;
+	}
+
+	/**
+	 * Open a hidden wrapper before admin notices render.
+	 *
+	 * WordPress core relocates `.notice` elements to just after the first
+	 * `.wp-header-end`. Opening the wrapper (and printing the catcher) before
+	 * any notice fires collects them all inside a hidden container, so the
+	 * Top Bar can sit at the very top of the page.
+	 *
+	 * @since 1.0.5
+	 *
+	 * @return void
+	 */
+	public function inject_before_notices(): void {
+		if ( ! $this->is_tryaura_admin_page() ) {
+			return;
+		}
+
+		echo '<div class="tryaura-notice-list-hide" id="tryaura__notice-list">';
+		echo '<div class="wp-header-end" id="tryaura__notice-catcher"></div>';
+	}
+
+	/**
+	 * Close the hidden notice wrapper opened in inject_before_notices().
+	 *
+	 * @since 1.0.5
+	 *
+	 * @return void
+	 */
+	public function inject_after_notices(): void {
+		if ( ! $this->is_tryaura_admin_page() ) {
+			return;
+		}
+
+		echo '</div>';
 	}
 
 	/**
@@ -154,13 +207,16 @@ class Admin {
 			'tryaura-admin',
 			'tryAura',
 			array(
-				'restUrl'        => esc_url_raw( rest_url() ),
-				'nonce'          => wp_create_nonce( 'wp_rest' ),
-				'apiKey'         => $api_key,
-				'imageModel'     => $image_model,
-				'videoModel'     => $video_model,
-				'optionKey'      => $this->option_key,
-				'wcExists'       => class_exists( 'WooCommerce' ),
+				'restUrl'                  => esc_url_raw( rest_url() ),
+				'nonce'                    => wp_create_nonce( 'wp_rest' ),
+				'apiKey'                   => $api_key,
+				'imageModel'               => $image_model,
+				'videoModel'               => $video_model,
+				'optionKey'                => $this->option_key,
+				'wcExists'                 => class_exists( 'WooCommerce' ),
+				'version'                  => $this->get_plugin_version( TRYAURA_FILE ),
+				'hasPro'                   => (bool) TryAura::is_pro_exists(),
+				'proVersion'               => TryAura::is_pro_exists() && defined( 'TRYAURAPRO_FILE' ) ? $this->get_plugin_version( TRYAURAPRO_FILE ) : '',
 				/**
 				 * Controls whether the Gemini API settings page is read-only.
 				 *
@@ -191,13 +247,32 @@ class Admin {
 	}
 
 	/**
+	 * Read a plugin version from its main file header.
+	 *
+	 * @since 1.0.5
+	 *
+	 * @param string $plugin_file Absolute path to the plugin main file.
+	 *
+	 * @return string Version string, or empty string when unreadable.
+	 */
+	private function get_plugin_version( string $plugin_file ): string {
+		$data = get_file_data( $plugin_file, array( 'Version' => 'Version' ), 'plugin' );
+
+		return $data['Version'] ?? '';
+	}
+
+	/**
 	 * Render the main admin page content.
 	 *
 	 * @since 1.0.0
 	 */
 	public function render_page(): void {
+		// The Top Bar mounts outside `.wrap` so it can span the full content
+		// width, and outside the `.tryaura` Tailwind scope whose importantized
+		// utilities would otherwise clobber the plugin-ui components.
+		echo '<div id="tryaura-admin-header"></div>';
 		echo '<div class="wrap">';
-		echo '<div id="tryaura-settings-root" class="tryaura"></div>';
+		echo '<div id="tryaura-settings-root" class="tryaura tryaura-admin-page-body"></div>';
 		echo '</div>';
 	}
 }

--- a/inc/Admin/Admin.php
+++ b/inc/Admin/Admin.php
@@ -2,6 +2,7 @@
 
 namespace Dokan\TryAura\Admin;
 
+use Dokan\TryAura\Admin\Promotion;
 use Dokan\TryAura\TryAura;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -36,6 +37,30 @@ class Admin {
 		// Capture admin notices so the Top Bar renders first on our page.
 		add_action( 'admin_notices', array( $this, 'inject_before_notices' ), -9999 );
 		add_action( 'admin_notices', array( $this, 'inject_after_notices' ), PHP_INT_MAX );
+
+		add_filter( 'plugin_action_links_' . plugin_basename( TRYAURA_FILE ), array( $this, 'add_settings_action_link' ) );
+	}
+
+	/**
+	 * Add the "Settings" action link on the All Plugins screen.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @param array $links Existing plugin action links.
+	 *
+	 * @return array
+	 */
+	public function add_settings_action_link( array $links ): array {
+		array_unshift(
+			$links,
+			sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( admin_url( 'admin.php?page=tryaura#/settings' ) ),
+				esc_html__( 'Settings', 'tryaura' )
+			)
+		);
+
+		return $links;
 	}
 
 	/**
@@ -217,6 +242,8 @@ class Admin {
 				'version'                  => $this->get_plugin_version( TRYAURA_FILE ),
 				'hasPro'                   => (bool) TryAura::is_pro_exists(),
 				'proVersion'               => TryAura::is_pro_exists() && defined( 'TRYAURAPRO_FILE' ) ? $this->get_plugin_version( TRYAURAPRO_FILE ) : '',
+				'upgradeToProUrl'          => Promotion::UPGRADE_URL,
+				'showUpgradeBanner'        => Promotion::should_show_upgrade_banner(),
 				/**
 				 * Controls whether the Gemini API settings page is read-only.
 				 *

--- a/inc/Admin/Promotion.php
+++ b/inc/Admin/Promotion.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Dokan\TryAura\Admin;
+
+use Dokan\TryAura\TryAura;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Pro promotion touchpoints shown while TryAura Pro is not active.
+ *
+ * Adds the "Upgrade" button to the TryAura admin sidebar menu and the
+ * "Upgrade to Pro" action link on the All Plugins screen. The dashboard
+ * promo banner is rendered by the admin SPA; its visibility is computed
+ * here (see should_show_upgrade_banner()).
+ *
+ * @since PLUGIN_SINCE
+ */
+class Promotion {
+	/**
+	 * User meta key storing the promo banner dismissal timestamp.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @var string
+	 */
+	const BANNER_DISMISSED_META_KEY = '_tryaura_promo_banner_dismissed_at';
+
+	/**
+	 * How long a banner dismissal lasts before the banner re-appears.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @var int
+	 */
+	const BANNER_DISMISSAL_DURATION = 30 * DAY_IN_SECONDS;
+
+	/**
+	 * Upgrade/pricing page URL.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @var string
+	 */
+	const UPGRADE_URL = 'https://storepulse.co/tryaura/pricing/';
+
+	/**
+	 * Bootstrap promotion hooks. All output is gated on Pro being absent.
+	 *
+	 * @since PLUGIN_SINCE
+	 */
+	public function __construct() {
+		if ( TryAura::is_pro_exists() ) {
+			return;
+		}
+
+		// After Admin::register_admin_page() (default priority) so the
+		// Upgrade entry lands after Dashboard and Settings.
+		add_action( 'admin_menu', array( $this, 'register_upgrade_menu' ), 20 );
+		add_action( 'admin_print_styles', array( $this, 'print_upgrade_menu_styles' ) );
+		add_action( 'admin_print_footer_scripts', array( $this, 'print_upgrade_menu_script' ) );
+
+		add_filter( 'plugin_action_links_' . plugin_basename( TRYAURA_FILE ), array( $this, 'add_upgrade_action_link' ) );
+	}
+
+	/**
+	 * Whether the promo banner should render for the current user.
+	 *
+	 * True when Pro is absent and the user has never dismissed the banner,
+	 * or the last dismissal is older than 30 days.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @return bool
+	 */
+	public static function should_show_upgrade_banner(): bool {
+		if ( TryAura::is_pro_exists() ) {
+			return false;
+		}
+
+		$dismissed_at = (int) get_user_meta( get_current_user_id(), self::BANNER_DISMISSED_META_KEY, true );
+
+		if ( ! $dismissed_at ) {
+			return true;
+		}
+
+		return ( time() - $dismissed_at ) > self::BANNER_DISMISSAL_DURATION;
+	}
+
+	/**
+	 * Append the "Upgrade" entry to the TryAura admin submenu.
+	 *
+	 * WordPress links submenu slugs starting with http(s) directly, so the
+	 * entry points straight at the pricing page.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @return void
+	 */
+	public function register_upgrade_menu(): void {
+		global $submenu;
+
+		if ( ! current_user_can( 'manage_options' ) || ! isset( $submenu['tryaura'] ) ) {
+			return;
+		}
+
+		$submenu['tryaura'][] = array( // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			__( 'Upgrade', 'tryaura' ),
+			'manage_options',
+			self::UPGRADE_URL,
+		);
+	}
+
+	/**
+	 * Style the sidebar Upgrade entry as a filled button.
+	 *
+	 * Printed on every admin page because the sidebar menu is global.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @return void
+	 */
+	public function print_upgrade_menu_styles(): void {
+		$selector = $this->upgrade_menu_selector();
+		?>
+		<style id="tryaura-upgrade-menu-style">
+			<?php echo $selector; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> {
+				display: inline-block;
+				margin: 4px 0 4px 10px;
+				padding: 4px 14px;
+				background: #ffd932;
+				color: #000000;
+				border-radius: 4px;
+				font-weight: 600;
+			}
+			<?php echo $selector; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>:hover,
+			<?php echo $selector; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>:focus {
+				background: #ffe164;
+				color: #000000;
+				box-shadow: none;
+			}
+		</style>
+		<?php
+	}
+
+	/**
+	 * CSS selector matching the sidebar Upgrade menu link.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @return string
+	 */
+	private function upgrade_menu_selector(): string {
+		return '#adminmenu #toplevel_page_tryaura .wp-submenu a[href^="' . esc_url( self::UPGRADE_URL ) . '"]';
+	}
+
+	/**
+	 * Open the sidebar Upgrade link in a new tab.
+	 *
+	 * Submenu entries render as plain anchors, so the target attribute has
+	 * to be added client-side (same approach as Elementor).
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @return void
+	 */
+	public function print_upgrade_menu_script(): void {
+		?>
+		<script id="tryaura-upgrade-menu-script">
+			document
+				.querySelectorAll( '<?php echo $this->upgrade_menu_selector(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>' )
+				.forEach( function ( link ) {
+					link.setAttribute( 'target', '_blank' );
+					link.setAttribute( 'rel', 'noopener noreferrer' );
+				} );
+		</script>
+		<?php
+	}
+
+	/**
+	 * Add the "Upgrade to Pro" action link on the All Plugins screen.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @param array $links Existing plugin action links.
+	 *
+	 * @return array
+	 */
+	public function add_upgrade_action_link( array $links ): array {
+		$links[] = sprintf(
+			'<a href="%s" target="_blank" rel="noopener noreferrer" style="color:#FF8C00;font-weight:700;">%s</a>',
+			esc_url( self::UPGRADE_URL ),
+			esc_html__( 'Upgrade to Pro', 'tryaura' )
+		);
+
+		return $links;
+	}
+}

--- a/inc/DependencyManagement/Providers/AdminServiceProvider.php
+++ b/inc/DependencyManagement/Providers/AdminServiceProvider.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use Dokan\TryAura\DependencyManagement\BaseServiceProvider;
 use Dokan\TryAura\Admin\Admin;
 use Dokan\TryAura\Admin\Enhancer;
+use Dokan\TryAura\Admin\Promotion;
 
 /**
  * AdminServiceProvider Class
@@ -25,8 +26,9 @@ class AdminServiceProvider extends BaseServiceProvider {
 	 * @var array
 	 */
 	protected $services = [
-		'admin'    => Admin::class,
-		'enhancer' => Enhancer::class,
+		'admin'     => Admin::class,
+		'enhancer'  => Enhancer::class,
+		'promotion' => Promotion::class,
 	];
 
 	/**

--- a/inc/DependencyManagement/Providers/RestServiceProvider.php
+++ b/inc/DependencyManagement/Providers/RestServiceProvider.php
@@ -12,6 +12,7 @@ use Dokan\TryAura\Rest\GenerateController;
 use Dokan\TryAura\Rest\DashboardController;
 use Dokan\TryAura\Rest\VideoThumbnailController;
 use Dokan\TryAura\Rest\ProductController;
+use Dokan\TryAura\Rest\PromotionController;
 
 /**
  * RestServiceProvider Class
@@ -33,6 +34,7 @@ class RestServiceProvider extends BaseServiceProvider {
 		'dashboard_controller'       => DashboardController::class,
 		'video_thumbnail_controller' => VideoThumbnailController::class,
 		'product_controller'         => ProductController::class,
+		'promotion_controller'       => PromotionController::class,
 	];
 
 	/**

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -98,6 +98,9 @@ class Plugin {
 		if ( $this->container->has( 'product_controller' ) ) {
 			$this->container->get( 'product_controller' );
 		}
+		if ( $this->container->has( 'promotion_controller' ) ) {
+			$this->container->get( 'promotion_controller' );
+		}
 
 		// Register assets.
 		if ( $this->container->has( 'assets' ) ) {
@@ -130,6 +133,10 @@ class Plugin {
 			}
 			if ( $this->container->has( 'admin_product_video' ) ) {
 				$this->container->get( 'admin_product_video' );
+			}
+			// Pro promotion touchpoints (sidebar Upgrade button, plugins screen link).
+			if ( $this->container->has( 'promotion' ) ) {
+				$this->container->get( 'promotion' );
 			}
 		}
 

--- a/inc/Rest/PromotionController.php
+++ b/inc/Rest/PromotionController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Dokan\TryAura\Rest;
+
+use Dokan\TryAura\Admin\Promotion;
+use WP_REST_Response;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * REST controller for Pro promotion state (promo banner dismissal).
+ *
+ * @since PLUGIN_SINCE
+ */
+class PromotionController {
+	/**
+	 * REST API namespace.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @var string api namespace.
+	 */
+	protected string $namespace = 'tryaura/v1';
+
+	/**
+	 * REST API base.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @var string rest base.
+	 */
+	protected string $rest_base = 'promotion';
+
+	/**
+	 * Class constructor.
+	 *
+	 * @since PLUGIN_SINCE
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register REST routes.
+	 *
+	 * @since PLUGIN_SINCE
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/dismiss-banner',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'dismiss_banner' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Simple permissions check: only admins (manage_options).
+	 *
+	 * @since PLUGIN_SINCE
+	 */
+	public function permissions_check(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Record the promo banner dismissal for the current user.
+	 *
+	 * Stores a timestamp so the banner can re-appear after the dismissal
+	 * duration (30 days) elapses.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function dismiss_banner(): WP_REST_Response {
+		update_user_meta( get_current_user_id(), Promotion::BANNER_DISMISSED_META_KEY, time() );
+
+		return new WP_REST_Response( array( 'dismissed' => true ) );
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@google/genai": "^1.34.0",
 				"@tailwindcss/postcss": "^4.1.18",
+				"@wedevs/plugin-ui": "github:getdokan/plugin-ui",
 				"@wordpress/api-fetch": "^7.36.0",
 				"@wordpress/components": "^30.9.0",
 				"@wordpress/data": "^10.37.0",
@@ -67,17 +68,23 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@ariakit/core": {
-			"version": "0.4.16",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.16.tgz",
-			"integrity": "sha512-nPJ0Be8d5ZvRApYGqdLMuYUjP7ktkPmTPOXyZFw+0Illk8LKgF3Q74ctVGuoQurJNDsANXcewzlyXK4vyIAGTA=="
+		"node_modules/@ariakit/components": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.7.tgz",
+			"integrity": "sha512-JbVGadO/Sf6S8dXSosB3nxbhjicxtMfrEuHyOgEKR7yY96VfEAIrLf1KrMuxJZ60a5XmzPKY1AY0N+0TKy6Rug==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/store": "0.1.6",
+				"@ariakit/utils": "0.1.4"
+			}
 		},
 		"node_modules/@ariakit/react": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.19.tgz",
-			"integrity": "sha512-n6q8leSQWXMk4vhcZlpnj8cIlAY0n+1bvVTwHvaVfmec4LjW49MFKkJRZd1AiV+SE73nkxPwSL3IbaS4p1aRxQ==",
+			"version": "0.4.34",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.34.tgz",
+			"integrity": "sha512-dstkfbRmC5Fz3uYwrkUDiD1b4Yx5BfL/WKYpasbwjHLDDUaJs/YhPAu837pvqUmJJo7T+UNF7cPCEmA97zN+UQ==",
+			"license": "MIT",
 			"dependencies": {
-				"@ariakit/react-core": "0.4.19"
+				"@ariakit/react-components": "0.3.3"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -88,19 +95,66 @@
 				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
-		"node_modules/@ariakit/react-core": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.19.tgz",
-			"integrity": "sha512-Aj+fu4pMyPXtlBghI+E7KSWItqJkbAqEhut3DlsFAjK9fQdHE+e1tQJG1PtnoEdD9BExkJWQ6R4M5a9HkEhqPA==",
+		"node_modules/@ariakit/react-components": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.3.3.tgz",
+			"integrity": "sha512-7J2HSIfrfSGv2lh8UDEo234Y/ZE8TvNxcukbgw6ibaaS6RES8w4kraANAsO5V1hQlAe8nhqDLwgj8dKGgWkC5A==",
+			"license": "MIT",
 			"dependencies": {
-				"@ariakit/core": "0.4.16",
-				"@floating-ui/dom": "^1.0.0",
-				"use-sync-external-store": "^1.2.0"
+				"@ariakit/components": "0.1.7",
+				"@ariakit/react-store": "0.1.7",
+				"@ariakit/react-utils": "0.2.2",
+				"@ariakit/store": "0.1.6",
+				"@ariakit/utils": "0.1.4",
+				"@floating-ui/dom": "^1.0.0"
 			},
 			"peerDependencies": {
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
+		},
+		"node_modules/@ariakit/react-store": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.7.tgz",
+			"integrity": "sha512-Wl8g69WyO1BJCjC5DmvE9PkvNhQHhKOebouEc5Kd7LdkH9GThk0ILbv3wKKPYPv4Av7G7gp6jIn2OQpPAZnmpA==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-utils": "0.2.2",
+				"@ariakit/store": "0.1.6",
+				"@ariakit/utils": "0.1.4",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@ariakit/react-utils": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.2.2.tgz",
+			"integrity": "sha512-C45KK/W9KxT3Ss+L8u4y0+WNxYLJRW2T+1mJKSKDTXnFPM8AmCJdrFWSlfr7kzci/hyWnWmlTCfjSf6g52C+hQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/store": "0.1.6",
+				"@ariakit/utils": "0.1.4"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@ariakit/store": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.6.tgz",
+			"integrity": "sha512-reQ8IXkgqutWtLdSeCu9fFL2N01JqngM3WUiBlH2IWcwxSzZJzYMZ010P6jWkVHrdyJDbcqXz84oUQX5e6iLnw==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/utils": "0.1.4"
+			}
+		},
+		"node_modules/@ariakit/utils": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.4.tgz",
+			"integrity": "sha512-gIC/FR/gcOtp2FQQDOnRPfxizJjqp4PSQWS7fH2tNr6O6iTwwW8CPao7VUpu8Y8xKeMXrvzHvkOHhBhfBf4OrA==",
+			"license": "MIT"
 		},
 		"node_modules/@asamuzakjp/css-color": {
 			"version": "3.2.0",
@@ -1921,12 +1975,10 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-			"integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1973,6 +2025,34 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@base-ui/utils": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+			"integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@floating-ui/utils": "^0.2.11",
+				"reselect": "^5.2.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@base-ui/utils/node_modules/reselect": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+			"integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+			"license": "MIT"
+		},
 		"node_modules/@bcoe/v8-coverage": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -1983,7 +2063,7 @@
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
 			"integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cacheable/utils": "^2.3.3",
@@ -1996,7 +2076,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
 			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"hashery": "^1.4.0",
@@ -2013,7 +2093,7 @@
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
 			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
@@ -2023,7 +2103,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
 			"integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"hashery": "^1.3.0",
@@ -2034,7 +2114,7 @@
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
 			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
@@ -2116,7 +2196,7 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
 			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2139,7 +2219,7 @@
 			"version": "1.0.26",
 			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
 			"integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2156,7 +2236,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
 			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2216,11 +2296,149 @@
 				"node": ">=10.0.0"
 			}
 		},
+		"node_modules/@dnd-kit/abstract": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/abstract/-/abstract-0.3.2.tgz",
+			"integrity": "sha512-uvPVK+SZYD6Viddn9M0K0JQdXknuVSxA/EbMlFRanve3P/XTc18oLa5zGftKSGjfQGmuzkZ34E26DSbly1zi3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/geometry": "^0.3.2",
+				"@dnd-kit/state": "^0.3.2",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@dnd-kit/accessibility": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+			"integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/collision": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/collision/-/collision-0.3.2.tgz",
+			"integrity": "sha512-pNmNSLCI8S9fNQ7QJ3fBCDjiT0sqBhUFcKgmyYaGvGCAU+kq0AP8OWlh0JSisc9k5mFyxmRpmFQcnJpILz/RPA==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/abstract": "^0.3.2",
+				"@dnd-kit/geometry": "^0.3.2",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@dnd-kit/core": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+			"integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/accessibility": "^3.1.1",
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/dom": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/dom/-/dom-0.3.2.tgz",
+			"integrity": "sha512-cIUAVgt2szQyz6JRy7I+0r+xeyOAGH21Y15hb5bIyHoDEaZBvIDH+OOlD9eoLjCbsxDLN9WloU2CBi3OE6LYDg==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/abstract": "^0.3.2",
+				"@dnd-kit/collision": "^0.3.2",
+				"@dnd-kit/geometry": "^0.3.2",
+				"@dnd-kit/state": "^0.3.2",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@dnd-kit/geometry": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/geometry/-/geometry-0.3.2.tgz",
+			"integrity": "sha512-3UBPuIS7E3oGiHxOE8h810QA+0pnrnCtGxl4Os1z3yy5YkC/BEYGY+TxWPTQaY1/OMV7GCX7ZNMlama2QN3n3w==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/state": "^0.3.2",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@dnd-kit/modifiers": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+			"integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.3.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/react": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/react/-/react-0.3.2.tgz",
+			"integrity": "sha512-1Opg1xw6I75Z95c+rF2NJa0pdGb8rLAENtuopKtJ1J0PudWlz+P6yL137xy/6DV43uaRmNGtsdbMbR0yRYJ72g==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/abstract": "^0.3.2",
+				"@dnd-kit/dom": "^0.3.2",
+				"@dnd-kit/state": "^0.3.2",
+				"tslib": "^2.6.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@dnd-kit/sortable": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+			"integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.3.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/state": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/state/-/state-0.3.2.tgz",
+			"integrity": "sha512-dLUIkoYrIJhGXfF2wGLTfb46vUokEsO/OoE21TSfmahYrx7ysTmnwbePsznFaHlwgZhQEh6AlLvthLCeY21b1A==",
+			"license": "MIT",
+			"dependencies": {
+				"@preact/signals-core": "^1.10.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@dnd-kit/utilities": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+			"integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
 		"node_modules/@dual-bundle/import-meta-resolve": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
 			"integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -2542,20 +2760,22 @@
 			}
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-			"integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+			"integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/utils": "^0.2.12"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-			"integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+			"integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/core": "^1.7.3",
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/core": "^1.8.0",
+				"@floating-ui/utils": "^0.2.12"
 			}
 		},
 		"node_modules/@floating-ui/react-dom": {
@@ -2571,9 +2791,10 @@
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.2.10",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-			"integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+			"integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+			"license": "MIT"
 		},
 		"node_modules/@formatjs/ecma402-abstract": {
 			"version": "2.3.6",
@@ -3517,7 +3738,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
 			"integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@leichtgewicht/ip-codec": {
@@ -3551,7 +3772,7 @@
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
 			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
 				"run-parallel": "^1.1.9"
@@ -3564,7 +3785,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
 			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">= 8"
 			}
@@ -3573,7 +3794,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
 			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
@@ -4609,6 +4830,16 @@
 			"integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
 			"dev": true
 		},
+		"node_modules/@preact/signals-core": {
+			"version": "1.14.4",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+			"integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			}
+		},
 		"node_modules/@prisma/instrumentation": {
 			"version": "6.11.1",
 			"resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.11.1.tgz",
@@ -4718,6 +4949,320 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/@radix-ui/primitive": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.6.tgz",
+			"integrity": "sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==",
+			"license": "MIT"
+		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+			"integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-context": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+			"integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dialog": {
+			"version": "1.1.20",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.20.tgz",
+			"integrity": "sha512-cngVJcvK0yMvR7wICJpv+1uW3Qw4T7QM5sdbb+oE/lxOdTdvF00oaRpWUjVgmjyXe3J+xh7eZyXZlVF3g2g59g==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.6",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-context": "1.2.0",
+				"@radix-ui/react-dismissable-layer": "1.1.16",
+				"@radix-ui/react-focus-guards": "1.1.4",
+				"@radix-ui/react-focus-scope": "1.1.13",
+				"@radix-ui/react-id": "1.1.2",
+				"@radix-ui/react-portal": "1.1.14",
+				"@radix-ui/react-presence": "1.1.8",
+				"@radix-ui/react-primitive": "2.1.7",
+				"@radix-ui/react-slot": "1.3.0",
+				"@radix-ui/react-use-controllable-state": "1.2.4",
+				"@radix-ui/react-use-layout-effect": "1.1.2",
+				"aria-hidden": "^1.2.4",
+				"react-remove-scroll": "^2.7.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dismissable-layer": {
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.16.tgz",
+			"integrity": "sha512-t45h68IjFx0ccBnPJqk0X6ecv69LkCFWd6DNCFQX56mUnVEXZbNOLCH/u9fHlAjFZ1RrFdl8/m4zev7B7NyhXQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.6",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-primitive": "2.1.7",
+				"@radix-ui/react-use-callback-ref": "1.1.2",
+				"@radix-ui/react-use-effect-event": "0.0.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-guards": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+			"integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-scope": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.13.tgz",
+			"integrity": "sha512-dE04aPEuP9rvKKT0d0KjSOtTEYNg6bmCYFsoSJpfC+y91Hic28ZfDCGgv6aJ+2Kw/LBXYipMZpyqVj/OD3Z8Gg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-primitive": "2.1.7",
+				"@radix-ui/react-use-callback-ref": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-id": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+			"integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-portal": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.14.tgz",
+			"integrity": "sha512-REwjAGPMa3J9oyDE4cuWkZbwnCbbyky66NurquQklXMSDn67cl6oGFx2gO7KZhPtFNbNw9xTWNrti3VIhgluYw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.7",
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-presence": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.8.tgz",
+			"integrity": "sha512-0hhyrQdXMaATgq4ammLG9+iPqsXxzZkgTSIxdrJHdfLnXO4Uo5L7BoO3/Xf0AEaettadGZWGGJMw6ujzQvIpGA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+			"integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.3.0"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+			"integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-callback-ref": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+			"integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-controllable-state": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.4.tgz",
+			"integrity": "sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.6",
+				"@radix-ui/react-use-effect-event": "0.0.3",
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-effect-event": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+			"integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+			"integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@reduxjs/toolkit": {
@@ -6794,14 +7339,285 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/a11y": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.38.0.tgz",
-			"integrity": "sha512-/xmHkUxQ2W5lDLp1jNOYWu2j9lrMqnV7bjs8X3jCTJ1fG2G60f+AGB1N0Qrwxf6rIfMIllDYoT5Ve2kbz2LBHQ==",
+		"node_modules/@wedevs/plugin-ui": {
+			"version": "2.0.0",
+			"resolved": "git+ssh://git@github.com/getdokan/plugin-ui.git#3404c77c543bed1990c6edd9fad4726d8d97cbb3",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/dom-ready": "^4.38.0",
-				"@wordpress/i18n": "^6.11.0"
+				"@base-ui/react": "^1.1.0",
+				"@dnd-kit/core": "^6.3.1",
+				"@dnd-kit/modifiers": "^9.0.0",
+				"@dnd-kit/react": "^0.3.0",
+				"@dnd-kit/sortable": "^10.0.0",
+				"@dnd-kit/utilities": "^3.2.2",
+				"@wordpress/api-fetch": "^7.43.0",
+				"@wordpress/components": "^32.5.0",
+				"@wordpress/dataviews": "^14.0.0",
+				"@wordpress/hooks": "^4.43.0",
+				"class-variance-authority": "^0.7.1",
+				"clsx": "^2.1.1",
+				"cmdk": "^1.1.1",
+				"input-otp": "^1.4.2",
+				"lucide-react": "^0.563.0",
+				"recharts": "^2.15.4",
+				"sonner": "^2.0.7",
+				"tailwind-merge": "^2.6.1",
+				"tw-animate-css": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=22"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wedevs/plugin-ui/node_modules/@base-ui/react": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+			"integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@base-ui/utils": "0.3.1",
+				"@floating-ui/react-dom": "^2.1.8",
+				"@floating-ui/utils": "^0.2.11",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@date-fns/tz": "^1.2.0",
+				"@types/react": "^17 || ^18 || ^19",
+				"date-fns": "^4.0.0",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@date-fns/tz": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				},
+				"date-fns": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wedevs/plugin-ui/node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+			"integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.8.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@wedevs/plugin-ui/node_modules/@wordpress/components": {
+			"version": "32.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.6.0.tgz",
+			"integrity": "sha512-MpOr0mGTkKDRjxK5LKm86Uoj9p9Z6KkrvhkNVi5zVKCftyHVMK+tun7wL2Qn/JZVLbxZpB1kW5sJ5aMf3T2ToA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
+				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.44.0",
+				"@wordpress/base-styles": "^6.20.0",
+				"@wordpress/compose": "^7.44.0",
+				"@wordpress/date": "^5.44.0",
+				"@wordpress/deprecated": "^4.44.0",
+				"@wordpress/dom": "^4.44.0",
+				"@wordpress/element": "^6.44.0",
+				"@wordpress/escape-html": "^3.44.0",
+				"@wordpress/hooks": "^4.44.0",
+				"@wordpress/html-entities": "^4.44.0",
+				"@wordpress/i18n": "^6.17.0",
+				"@wordpress/icons": "^12.2.0",
+				"@wordpress/is-shallow-equal": "^5.44.0",
+				"@wordpress/keycodes": "^4.44.0",
+				"@wordpress/primitives": "^4.44.0",
+				"@wordpress/private-apis": "^1.44.0",
+				"@wordpress/rich-text": "^7.44.0",
+				"@wordpress/warning": "^3.44.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wedevs/plugin-ui/node_modules/@wordpress/components/node_modules/date-fns": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
+		"node_modules/@wedevs/plugin-ui/node_modules/@wordpress/icons": {
+			"version": "12.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-12.2.0.tgz",
+			"integrity": "sha512-Fiw7bmfHDNPjTdCrBF23/9K0VN/GUi73d2ZPZaeWdXhTmIX62T9KYvb1c+WnlBkX7GpXgJO6Q8mypQCY9mw5SQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.44.0",
+				"@wordpress/primitives": "^4.44.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wedevs/plugin-ui/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wedevs/plugin-ui/node_modules/lucide-react": {
+			"version": "0.563.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.563.0.tgz",
+			"integrity": "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wedevs/plugin-ui/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"license": "MIT"
+		},
+		"node_modules/@wedevs/plugin-ui/node_modules/recharts": {
+			"version": "2.15.4",
+			"resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+			"integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+			"deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+			"license": "MIT",
+			"dependencies": {
+				"clsx": "^2.0.0",
+				"eventemitter3": "^4.0.1",
+				"lodash": "^4.17.21",
+				"react-is": "^18.3.1",
+				"react-smooth": "^4.0.4",
+				"recharts-scale": "^0.4.4",
+				"tiny-invariant": "^1.3.1",
+				"victory-vendor": "^36.6.8"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wedevs/plugin-ui/node_modules/tailwind-merge": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
+			"integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/dcastil"
+			}
+		},
+		"node_modules/@wedevs/plugin-ui/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/@wedevs/plugin-ui/node_modules/victory-vendor": {
+			"version": "36.9.2",
+			"resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+			"integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+			"license": "MIT AND ISC",
+			"dependencies": {
+				"@types/d3-array": "^3.0.3",
+				"@types/d3-ease": "^3.0.0",
+				"@types/d3-interpolate": "^3.0.1",
+				"@types/d3-scale": "^4.0.2",
+				"@types/d3-shape": "^3.1.0",
+				"@types/d3-time": "^3.0.0",
+				"@types/d3-timer": "^3.0.0",
+				"d3-array": "^3.1.6",
+				"d3-ease": "^3.0.1",
+				"d3-interpolate": "^3.0.1",
+				"d3-scale": "^4.0.2",
+				"d3-shape": "^3.1.0",
+				"d3-time": "^3.0.0",
+				"d3-timer": "^3.0.1"
+			}
+		},
+		"node_modules/@wordpress/a11y": {
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.51.0.tgz",
+			"integrity": "sha512-ophPwL3J31JOA46koDonBz7EL1dMfpKLEj8crD2uCK5IYzvqlYJrLA0o+RfPUUHrbXa51qGBSZ/+Bprb6nao+g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/dom-ready": "^4.51.0",
+				"@wordpress/i18n": "^6.24.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -6809,13 +7625,14 @@
 			}
 		},
 		"node_modules/@wordpress/api-fetch": {
-			"version": "7.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.38.0.tgz",
-			"integrity": "sha512-RISdjFjAoXWY9WcnHq05sqTAuKCcMwe+4y+hjZZLix0PUgeClQ2GxfO1iAIfPSI/SMcFqlSvkW5k7k2jixsudw==",
+			"version": "7.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.51.0.tgz",
+			"integrity": "sha512-kSgBvrGr8eMTcQTA1fIsChg56FKPTdcmkQrpEQjL9uzbmGwPKrru4BdkBFqLSql/PH5fEOjNcY3OSA61+WrJ8g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.11.0",
-				"@wordpress/url": "^4.38.0"
+				"@wordpress/i18n": "^6.24.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/url": "^4.51.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -7046,9 +7863,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.14.0.tgz",
-			"integrity": "sha512-0NoWb5+gVGUMZ8RiAE4g4dJ08ZdSMrWdnt/fp//BclezTdOLepZPzZ9O6nDWLVdlNgnYLhPwK/t5jxOow5WRoA==",
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.20.0.tgz",
+			"integrity": "sha512-Dsug4Zxz2xOFtK6CGThKYXwCqC9Yztw2STKQzwztrX4yW+o6iDbzkxpcwdDhsaVJs0Jt9A4LmJpZPh+pUozzLA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -7155,21 +7972,20 @@
 			}
 		},
 		"node_modules/@wordpress/compose": {
-			"version": "7.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.38.0.tgz",
-			"integrity": "sha512-qWQ+SBuMm1cduo6rT6auHrETux0sLkmanoOWAM1FMpx+1GH6G9CGeRcCjPTW0AeXpioDNGCRoLy3O+HbEDhC7A==",
+			"version": "7.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.46.0.tgz",
+			"integrity": "sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.38.0",
-				"@wordpress/dom": "^4.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/is-shallow-equal": "^5.38.0",
-				"@wordpress/keycodes": "^4.38.0",
-				"@wordpress/priority-queue": "^3.38.0",
-				"@wordpress/undo-manager": "^1.38.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/priority-queue": "^3.46.0",
+				"@wordpress/undo-manager": "^1.46.0",
 				"change-case": "^4.1.2",
-				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
 			},
@@ -7182,19 +7998,19 @@
 			}
 		},
 		"node_modules/@wordpress/data": {
-			"version": "10.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.38.0.tgz",
-			"integrity": "sha512-z+JftoaEotRp5K9O0j8XJJFAeSHl1PJU75C/KD5MG+7oth4FO6dI0juY5AMt8zlLsyuB+Q+zT4fkO+qxd+JF6w==",
+			"version": "10.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.51.0.tgz",
+			"integrity": "sha512-KwlrgU+PGd+l4QyrwuCvbHE5HUC1CU6pqD19WZr+yOD1XRmIWZ+LZNwrEdFlhCu8aOG9+e131k1zmAMZign/mA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/compose": "^7.38.0",
-				"@wordpress/deprecated": "^4.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/is-shallow-equal": "^5.38.0",
-				"@wordpress/priority-queue": "^3.38.0",
-				"@wordpress/private-apis": "^1.38.0",
-				"@wordpress/redux-routine": "^5.38.0",
-				"deepmerge": "^4.3.0",
+				"@wordpress/compose": "^8.4.0",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/is-shallow-equal": "^5.51.0",
+				"@wordpress/priority-queue": "^3.51.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/redux-routine": "^5.51.0",
+				"deepmerge": "^4.3.1",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
@@ -7207,7 +8023,66 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0"
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/data/node_modules/@wordpress/compose": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.4.0.tgz",
+			"integrity": "sha512-oVmRQ05Rlzh+W7oFb6CGmNm9SDozd3VEVYhXO4CcTpz0vkn7bEcwIMIdaKq49X8vORW1htJa/myBbYJATpamNg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/dom": "^4.51.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/is-shallow-equal": "^5.51.0",
+				"@wordpress/keycodes": "^4.51.0",
+				"@wordpress/priority-queue": "^3.51.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/undo-manager": "^1.51.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/data/node_modules/@wordpress/element": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
+			"integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/escape-html": "^3.51.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/data/node_modules/is-plain-object": {
@@ -7219,13 +8094,202 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/@wordpress/date": {
-			"version": "5.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.38.0.tgz",
-			"integrity": "sha512-WyXChgB3dHfOi/BQSx9yJol883XNABGH73fm7M0RnGUyhM6ueE5kYfgsNycWN5v5/ZP4deUe+heab+JE18ZQeg==",
+		"node_modules/@wordpress/dataviews": {
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-14.3.0.tgz",
+			"integrity": "sha512-2fFSgyatDldjPb2gO+vLDwkbI2Jw+8zd/O0/BwLftQ5QhrrRtAqECFp+eYzcQ8Onh8OMhxq0n7tsaIHE/jWqJQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.38.0",
+				"@ariakit/react": "^0.4.21",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/components": "^33.1.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/data": "^10.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/ui": "^0.13.0",
+				"@wordpress/warning": "^3.46.0",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^4.1.0",
+				"deepmerge": "4.3.1",
+				"fast-deep-equal": "^3.1.3",
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/base-styles": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-8.0.0.tgz",
+			"integrity": "sha512-livtgwnvBm7xbpm/gaBxwtdZm3KCXq210UNsr48WA8TGfi/OfZ4oOzk4Mp4/ZHsq2baaXzhZ0iXjyR7oyaOTsw==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
+			"version": "33.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
+			"integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
+				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/escape-html": "^3.46.0",
+				"@wordpress/hooks": "^4.46.0",
+				"@wordpress/html-entities": "^4.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/rich-text": "^7.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/warning": "^3.46.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
+			"integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/escape-html": "^3.51.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"license": "MIT"
+		},
+		"node_modules/@wordpress/dataviews/node_modules/uuid": {
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+			"integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
+		"node_modules/@wordpress/date": {
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.51.0.tgz",
+			"integrity": "sha512-clBSLSnP799BYGq97i9JX8oqNMAK37omFGig1+OFDxKqHj6iuM4UA9teOBlUFkHuldLc4I4MQcuLi/Ic6AF7fg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.51.0",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -7259,12 +8323,12 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.38.0.tgz",
-			"integrity": "sha512-pGw2VVGQwW6VXgAlsjQnPV/H2btQ9CIv/xLBvaPtWLAbWQsB9r4Fb7ZBTKPsMA16f8mzQxHyhd8y4NL6HhQUtw==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.51.0.tgz",
+			"integrity": "sha512-6pgnUvz7oQRwpJh+aM/dPBs5GBPTyOj+XKGeyzKPKHqbaWeSzkHVI9bhgs+Ajamn/jERK5TgH+VAq/gwfvfO+g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/hooks": "^4.38.0"
+				"@wordpress/hooks": "^4.51.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -7272,12 +8336,12 @@
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.38.0.tgz",
-			"integrity": "sha512-STaByZ7YYqlNxhb4e5JvyG7vy4twyszOpDk6IHKp/NVJUGntg12yrDvsAHfAWOxLef7Z0jgCdOC+6QXL4Pfksg==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.51.0.tgz",
+			"integrity": "sha512-POkQoNBzLFlHaVzJakgF5X/xj4nERsLa5uTAvt3i7YFr9tep3uLtOFCJiiZM1vzO5iVtYSBWxmWyDkJPsOSy6g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.38.0"
+				"@wordpress/deprecated": "^4.51.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -7285,9 +8349,9 @@
 			}
 		},
 		"node_modules/@wordpress/dom-ready": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.38.0.tgz",
-			"integrity": "sha512-HEH3NaLEQS5fk9Do7GpWQpYCl6q0ehoBE7AJhyARoZPDGo5Uuizv4asr0rXKYM0kD29rDoIHp2u7KDba/MH8gQ==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.51.0.tgz",
+			"integrity": "sha512-O/ivmzG+o44CicTW+c17KBXlmjRoVp4VGIyyEQDD52H5YH+gX7i15FuEPk6G2e7Rqz4DCvCS5yD7eY9Zb3z1WA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -7317,14 +8381,14 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.38.0.tgz",
-			"integrity": "sha512-4N9xtuE2TIvaZ037fQREKrBw4TTt90PWswAfNFvxUVu5vdp91PLuR6rmeO0ohKg2CJLzozQLEKZF+6VuSaYowQ==",
+			"version": "6.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
+			"integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.38.0",
+				"@wordpress/escape-html": "^3.46.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -7345,9 +8409,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.38.0.tgz",
-			"integrity": "sha512-LItqIdFnn/JAVEzTtvDZGJfsdmzeIE4ryMjovHkJhRElzcQWKHuq806DMprL40NcvJbdn0YfJZSv+aeP+9Ah3g==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.51.0.tgz",
+			"integrity": "sha512-0jPCm9WqpB7S+mdhkjjikBzGo06xAgvmgwtSP1v44P5tKNGujcbsvKj+JW0m60FJxNBmaZPvGu2e/DlY4iljVQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -7451,9 +8515,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.38.0.tgz",
-			"integrity": "sha512-nrLo2semyTID4yIlu9/DSKVM9v61Mgrkyr+MNj7LgzlD3PuGjYNzXVh5+ngfgPoKVdhV3kzFhda+1PZ8SK8cYg==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.51.0.tgz",
+			"integrity": "sha512-pTVZRT9mjEdrNNt7TyKw5hQhFUqntfTXVs/fboEDpmAi+PFWXoD8rPs3oZyRCVr/MDyE6OCv1mwEibI6AsRk3Q==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -7461,9 +8525,9 @@
 			}
 		},
 		"node_modules/@wordpress/html-entities": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.38.0.tgz",
-			"integrity": "sha512-xe9OHCLft2jsxDhFPsPpzTTh4g/I5kXufDOj+og6+dC3Ut7ZmNjimm41rY9S+wfNYXJDonTiW51xSFq1NSl9yw==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.51.0.tgz",
+			"integrity": "sha512-rkWpUWbO7FlGzicae0tAlmDj6gTTh/SLXbuRKlPLvG4W8dokSuv+q491aes14VvDY9u4sFeRduQt+nXivfxpfQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -7471,13 +8535,13 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.11.0.tgz",
-			"integrity": "sha512-JOJk1LtKACxnQ8MQEJAOSdJxUaYupxXzk3CPGWRzhxPHQ9xWH8LS0NqGppUebcah4s4uu26vqACiZvTt93N4eA==",
+			"version": "6.24.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.24.0.tgz",
+			"integrity": "sha512-K4XmCyyyDOKH/5ea75P2L36ZiAvQTy4Hsa73Na3n6NzVjAwrrKZm4JJGf0t+OlThUG4D4GyfEv5szs5EeCA0lA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.38.0",
+				"@wordpress/hooks": "^4.51.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -7508,9 +8572,9 @@
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.38.0.tgz",
-			"integrity": "sha512-KR2rAUI3ECN86+8VNS0kdlPwXL8exZQo5bNWG0DgUyY3ZlbzYYWXdvqL5zNr2USr93BjFYd87yE+lH9/TbZ6Lg==",
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.51.0.tgz",
+			"integrity": "sha512-Ivyf85r9trFfl/rRaDMgghFZ+gzw8yIl7/vDPagYkvq9Xnqw8KecPy91BqIIvco1jIOh3RXPP6cbVu3dTqZDMA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -7555,16 +8619,24 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.38.0.tgz",
-			"integrity": "sha512-J00DFUe83KWyHFSi48yw7DWeKH7J50DlzXOFVDsTW5SygWggt7t1pVxLsIqk9NCBhJsf73Fnq/d4dkDLup1npg==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.51.0.tgz",
+			"integrity": "sha512-C9CZq2WCWVacjsHhFgM0GVIQmTUxo/oX7U+Qj0kr3vWHZu6cmEDJ94PX+f02M3b+iHnCk4oHCvnXGANwKQwsSw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.11.0"
+				"@wordpress/i18n": "^6.24.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
@@ -7731,12 +8803,12 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.38.0.tgz",
-			"integrity": "sha512-mba5ua+9xifdfXqMDpFupcowJN/DTcQJaQ0cISFtEhe9jmMVc63yFUlaDgqphGUA1ydhItp8u7Kx4m3GxB5BQQ==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.51.0.tgz",
+			"integrity": "sha512-vSg8XYGyBL9+s1h67Fhx8vV718iM9jto8/Tx5tyEdPHXuvY9F8hi3FLZ8k/DQ7qGy+o3ljDsfl1dq9DHP/Fs0A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.38.0",
+				"@wordpress/element": "^8.3.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -7744,13 +8816,48 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0"
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
+			"integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/escape-html": "^3.51.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/primitives/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
-			"version": "3.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.38.0.tgz",
-			"integrity": "sha512-REUN3SNVKEskpiib/XDzXMNZIOH7R/w2k4tDwo0r83Fz/Z+Uwbft9dirnrP7J/l3SRRGAEKteYYa+OXPZ8Ryaw==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.51.0.tgz",
+			"integrity": "sha512-Mgm6DFRW4ZqgkVTQNe6LdtWzah19u6531Uf1L5q1LwYd/eekKeRsNB9dJnqBg2Kn/jgfPbZnTaHToDvnOZQgcA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"requestidlecallback": "^0.3.0"
@@ -7761,9 +8868,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.38.0.tgz",
-			"integrity": "sha512-6Hj9x3xJb64Xu/p2M4XA9fGeY2omTly2bb+Kayaa55eEZi6iXlcIhvv7UAdKhJ2PF9hfuENccgqhG7OrvaEEJg==",
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.51.0.tgz",
+			"integrity": "sha512-x3FeBDGegBAKveYHNmgZgTbEwuwVMxGouTR2fKP94Myn5PzF5EkZK1CZJrDnfNjzTl73nCwsd4IXACdtYfnnAQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -7771,9 +8878,9 @@
 			}
 		},
 		"node_modules/@wordpress/redux-routine": {
-			"version": "5.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.38.0.tgz",
-			"integrity": "sha512-UC7XpM2s3SVINieWDuEgGdoNLFe6fFuljXaI4/2CZOu4iM6kPruv4K/XWImsnV41cfcL08egHd9r4RUdhrdscw==",
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.51.0.tgz",
+			"integrity": "sha512-L5wLAEMPXjE7HvyD2ErH7HL0vgAhXGN9if0yc/r42nnyt9Mq/5B7MOjGJL7qpBb0VoBsUvqPoLEIZmIPU+OF+A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"is-plain-object": "^5.0.0",
@@ -7798,21 +8905,22 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
-			"version": "7.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.38.0.tgz",
-			"integrity": "sha512-PffqVNJqpnhJn8zRm1ap/aWsBqjNcteyRmx277WwPvzHkvYY3OF/SH9R6UOhGRTNPlhKCWkWvvhEw+DpPtqdKQ==",
+			"version": "7.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.51.0.tgz",
+			"integrity": "sha512-SYe7N6GMTZ3DMwNrC69EuFc/tv0KJNfWKoLJWOepIJuuseWj+JVrSAUO13Dv1c8Q0syr8zR2RJvS5G4jiMgAsA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/a11y": "^4.38.0",
-				"@wordpress/compose": "^7.38.0",
-				"@wordpress/data": "^10.38.0",
-				"@wordpress/deprecated": "^4.38.0",
-				"@wordpress/dom": "^4.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/escape-html": "^3.38.0",
-				"@wordpress/i18n": "^6.11.0",
-				"@wordpress/keycodes": "^4.38.0",
-				"colord": "2.9.3",
+				"@wordpress/a11y": "^4.51.0",
+				"@wordpress/compose": "^8.4.0",
+				"@wordpress/data": "^10.51.0",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/dom": "^4.51.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/escape-html": "^3.51.0",
+				"@wordpress/i18n": "^6.24.0",
+				"@wordpress/keycodes": "^4.51.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"colord": "^2.9.3",
 				"memize": "^2.1.0"
 			},
 			"engines": {
@@ -7820,7 +8928,75 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0"
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/rich-text/node_modules/@wordpress/compose": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.4.0.tgz",
+			"integrity": "sha512-oVmRQ05Rlzh+W7oFb6CGmNm9SDozd3VEVYhXO4CcTpz0vkn7bEcwIMIdaKq49X8vORW1htJa/myBbYJATpamNg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/dom": "^4.51.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/is-shallow-equal": "^5.51.0",
+				"@wordpress/keycodes": "^4.51.0",
+				"@wordpress/priority-queue": "^3.51.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/undo-manager": "^1.51.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
+			"integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/escape-html": "^3.51.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/rich-text/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@wordpress/scripts": {
@@ -8038,6 +9214,16 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@wordpress/style-runtime": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.2.0.tgz",
+			"integrity": "sha512-9pLmilkgWqTvIlrnnXbW7ECfEPvCSYOve7btXgYGgMOzrGs12ijnG+kSGGg0aJhEV8OCzQ/QdVBh4s1zQZ0bLQ==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
 		"node_modules/@wordpress/stylelint-config": {
 			"version": "23.30.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.30.0.tgz",
@@ -8086,13 +9272,167 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/undo-manager": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.38.0.tgz",
-			"integrity": "sha512-5dwOkqVWXikDqiYIPP0dNYMYpVQVP5ov8+nwksLJkrjruzqbeSL9L8n7khs0UAyw1bpsxtagb61JdY+ddunbKw==",
+		"node_modules/@wordpress/ui": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.13.0.tgz",
+			"integrity": "sha512-NSP/Hh6X3qbN0B7KsWFGZfmiYp28NiVZnxu8uJSspZs9mzVP+qKC9yOgIxPYIjFuGDrXJ6QK9wL3soRXkJMG0w==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/is-shallow-equal": "^5.38.0"
+				"@base-ui/react": "^1.4.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/theme": "^0.13.0",
+				"clsx": "^2.1.1",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@base-ui/react": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+			"integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@base-ui/utils": "0.3.1",
+				"@floating-ui/react-dom": "^2.1.8",
+				"@floating-ui/utils": "^0.2.11",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@date-fns/tz": "^1.2.0",
+				"@types/react": "^17 || ^18 || ^19",
+				"date-fns": "^4.0.0",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@date-fns/tz": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				},
+				"date-fns": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@floating-ui/react-dom": {
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+			"integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.8.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
+			"integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/escape-html": "^3.51.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/theme": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.13.0.tgz",
+			"integrity": "sha512-4Lasso3BPej43c7e+eO+YN/fl/mcg/Q9+nclp1FmV6xdWFiUXvfwAOsEeNQQ/5s5mw5aCgseK3//qX5gydhfUA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/undo-manager": {
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.51.0.tgz",
+			"integrity": "sha512-w/vUyQX2m+X2xDYCdxu/ALHJdE5S0vkWbxFhUJJeBJG66IFs/DGk/NmLCOudUFLFMQYSXFyIm1XsIPT0UdjhCA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/is-shallow-equal": "^5.51.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8100,9 +9440,9 @@
 			}
 		},
 		"node_modules/@wordpress/url": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.38.0.tgz",
-			"integrity": "sha512-Pzt5QvX3+7Co++X3wZxOGeVvSzjslYejt2R/ZHp2T9qxHCuiAVWnEttOSeAxziwjiPeiOclrbfOVTUvPqK0Ftw==",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.51.0.tgz",
+			"integrity": "sha512-lPjifvknjTfBl8OSS76jsALotvuSWvb5lE8YKeFJ+zwV09q0ZHgQTeMKHrL47DwMl+PlPhmoLrjHav+KLBwTCA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"remove-accents": "^0.5.0"
@@ -8113,9 +9453,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.38.0.tgz",
-			"integrity": "sha512-4eHJoNC/Ofrp+hOIf/2KqSoyIZLFIoyAhfTBrFxq3bGKNFJlOEHAJ3+tGiy77Ja93uQzrSWctZsH1CpSRYKkng==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.51.0.tgz",
+			"integrity": "sha512-wWeM6pjAWbMhdNfgCaxi5yhLzomj6/trcIjGPi2Q4kaIuxUula8Ybq0ZPn5lYuc19ICkcGYcAnWNYz/4mYCHdA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -8606,6 +9946,18 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"node_modules/aria-hidden": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+			"integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/aria-query": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -8672,7 +10024,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -8824,7 +10176,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -9367,7 +10719,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"fill-range": "^7.1.1"
 			},
@@ -9488,7 +10840,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
 			"integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cacheable/memory": "^2.0.7",
@@ -9502,7 +10854,7 @@
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
 			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
@@ -9810,15 +11162,16 @@
 			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
 			"dev": true
 		},
-		"node_modules/clipboard": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
-			"integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
-			"license": "MIT",
+		"node_modules/class-variance-authority": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+			"integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"good-listener": "^1.2.2",
-				"select": "^1.1.2",
-				"tiny-emitter": "^2.0.0"
+				"clsx": "^2.1.1"
+			},
+			"funding": {
+				"url": "https://polar.sh/cva"
 			}
 		},
 		"node_modules/cliui": {
@@ -9858,6 +11211,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/cmdk": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+			"integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "^1.1.1",
+				"@radix-ui/react-dialog": "^1.1.6",
+				"@radix-ui/react-id": "^1.1.0",
+				"@radix-ui/react-primitive": "^2.0.2"
+			},
+			"peerDependencies": {
+				"react": "^18 || ^19 || ^19.0.0-rc",
+				"react-dom": "^18 || ^19 || ^19.0.0-rc"
 			}
 		},
 		"node_modules/co": {
@@ -9907,7 +11276,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
 			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -10424,7 +11792,7 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
 			"integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12 || >=16"
@@ -10522,7 +11890,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-			"dev": true,
+			"devOptional": true,
 			"bin": {
 				"cssesc": "bin/cssesc"
 			},
@@ -11076,12 +12444,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/delegate": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-			"license": "MIT"
-		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -11125,6 +12487,12 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
+		"node_modules/detect-node-es": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+			"license": "MIT"
+		},
 		"node_modules/devtools-protocol": {
 			"version": "0.0.1507524",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
@@ -11144,7 +12512,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"path-type": "^4.0.0"
 			},
@@ -11174,6 +12542,16 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/dom-helpers": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+			"integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.8.7",
+				"csstype": "^3.0.2"
 			}
 		},
 		"node_modules/dom-serializer": {
@@ -11412,7 +12790,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
 			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -12557,8 +13935,7 @@
 		"node_modules/eventemitter3": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-			"dev": true
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
 		},
 		"node_modules/events": {
 			"version": "3.3.0",
@@ -12758,6 +14135,15 @@
 			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
 			"dev": true
 		},
+		"node_modules/fast-equals": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.1.tgz",
+			"integrity": "sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/fast-fifo": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -12768,7 +14154,7 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
 			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -12784,7 +14170,7 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"is-glob": "^4.0.1"
 			},
@@ -12808,7 +14194,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
 			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -12824,7 +14210,7 @@
 			"version": "1.0.16",
 			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
 			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">= 4.9.1"
 			}
@@ -12833,7 +14219,7 @@
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
 			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
 			}
@@ -12933,7 +14319,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -13204,7 +14590,7 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
 			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.11",
@@ -13565,6 +14951,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/get-nonce": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/get-package-type": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -13874,7 +15269,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
 			"integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/goober": {
@@ -13884,15 +15279,6 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"csstype": "^3.0.10"
-			}
-		},
-		"node_modules/good-listener": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-			"integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
-			"license": "MIT",
-			"dependencies": {
-				"delegate": "^3.1.2"
 			}
 		},
 		"node_modules/google-auth-library": {
@@ -14013,7 +15399,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -14076,7 +15462,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
 			"integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"hookified": "^1.14.0"
@@ -14140,7 +15526,7 @@
 			"version": "1.15.0",
 			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.0.tgz",
 			"integrity": "sha512-51w+ZZGt7Zw5q7rM3nC4t3aLn/xvKDETsXqMczndvwyVQhAHfUmUuFBRFcos8Iyebtk7OAE9dL26wFNzZVVOkw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/hosted-git-info": {
@@ -14263,7 +15649,7 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
 			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -14553,7 +15939,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=0.8.19"
 			}
@@ -14589,8 +15975,18 @@
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC"
+		},
+		"node_modules/input-otp": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
+			"integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+			}
 		},
 		"node_modules/internal-slot": {
 			"version": "1.1.0",
@@ -14880,7 +16276,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -14940,7 +16336,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"is-extglob": "^2.1.1"
 			},
@@ -14976,7 +16372,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -16446,7 +17842,7 @@
 			"version": "0.37.0",
 			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
 			"integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/language-subtag-registry": {
@@ -17077,7 +18473,6 @@
 			"version": "4.17.23",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
 			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash-es": {
@@ -17109,7 +18504,7 @@
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
 			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.uniq": {
@@ -17387,7 +18782,7 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
 			"integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -17516,7 +18911,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">= 8"
 			}
@@ -17541,7 +18936,7 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
@@ -17981,7 +19376,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -18141,7 +19536,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -18703,7 +20097,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -19384,14 +20778,14 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
 			"integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/postcss-safe-parser": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
 			"integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -19489,7 +20883,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/postgres-array": {
 			"version": "2.0.0",
@@ -19639,7 +21033,6 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -19649,8 +21042,7 @@
 		"node_modules/prop-types/node_modules/react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"dev": true
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"node_modules/protobufjs": {
 			"version": "7.5.4",
@@ -19794,7 +21186,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
 			"integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"hookified": "^1.14.0"
@@ -19822,7 +21214,7 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -20018,6 +21410,53 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/react-remove-scroll": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+			"integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+			"license": "MIT",
+			"dependencies": {
+				"react-remove-scroll-bar": "^2.3.7",
+				"react-style-singleton": "^2.2.3",
+				"tslib": "^2.1.0",
+				"use-callback-ref": "^1.3.3",
+				"use-sidecar": "^1.1.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-remove-scroll-bar": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+			"integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+			"license": "MIT",
+			"dependencies": {
+				"react-style-singleton": "^2.2.2",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/react-router": {
 			"version": "7.13.0",
 			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
@@ -20067,6 +21506,59 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/react-smooth": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+			"integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-equals": "^5.0.1",
+				"prop-types": "^15.8.1",
+				"react-transition-group": "^4.4.5"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/react-style-singleton": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+			"integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+			"license": "MIT",
+			"dependencies": {
+				"get-nonce": "^1.0.0",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-transition-group": {
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+			"integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@babel/runtime": "^7.5.5",
+				"dom-helpers": "^5.0.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2"
+			},
+			"peerDependencies": {
+				"react": ">=16.6.0",
+				"react-dom": ">=16.6.0"
 			}
 		},
 		"node_modules/read-cache": {
@@ -20244,6 +21736,15 @@
 				"react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
+		"node_modules/recharts-scale": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+			"integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+			"license": "MIT",
+			"dependencies": {
+				"decimal.js-light": "^2.4.1"
+			}
+		},
 		"node_modules/recharts/node_modules/eventemitter3": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -20330,11 +21831,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
 		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.4",
@@ -20641,7 +22137,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -20740,7 +22236,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -20777,7 +22273,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
 			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
@@ -20897,7 +22393,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
 			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -21143,12 +22639,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true
-		},
-		"node_modules/select": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-			"integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
-			"license": "MIT"
 		},
 		"node_modules/select-hose": {
 			"version": "2.0.0",
@@ -21586,7 +23076,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true,
+			"devOptional": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -21595,7 +23085,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
 			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -21665,6 +23155,16 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/sonner": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+			"integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+				"react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
 			}
 		},
 		"node_modules/source-map": {
@@ -22216,7 +23716,7 @@
 			"version": "16.26.1",
 			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
 			"integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -22402,7 +23902,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
 			"integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -22426,7 +23926,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
 			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -22449,21 +23949,21 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Python-2.0"
 		},
 		"node_modules/stylelint/node_modules/balanced-match": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
 			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/stylelint/node_modules/cosmiconfig": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
 			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.1",
@@ -22490,7 +23990,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
 			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"mdn-data": "2.12.2",
@@ -22504,7 +24004,7 @@
 			"version": "11.1.2",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
 			"integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"flat-cache": "^6.1.20"
@@ -22514,7 +24014,7 @@
 			"version": "6.1.20",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
 			"integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"cacheable": "^2.3.2",
@@ -22526,7 +24026,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
 			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"global-prefix": "^3.0.0"
@@ -22539,7 +24039,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
 			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ini": "^1.3.5",
@@ -22554,7 +24054,7 @@
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"array-union": "^2.1.0",
@@ -22575,7 +24075,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -22585,7 +24085,7 @@
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
 			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -22595,7 +24095,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
 			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -22605,7 +24105,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
 			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -22618,7 +24118,7 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -22628,14 +24128,14 @@
 			"version": "2.12.2",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
 			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/stylelint/node_modules/meow": {
 			"version": "13.2.0",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
 			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -22648,7 +24148,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -22662,7 +24162,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -22675,7 +24175,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -22688,7 +24188,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
 			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
@@ -22707,7 +24207,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -22719,7 +24219,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
 			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0",
@@ -22753,7 +24253,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
 			"integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/svgo": {
 			"version": "3.3.2",
@@ -22811,11 +24311,17 @@
 				"url": "https://opencollective.com/synckit"
 			}
 		},
+		"node_modules/tabbable": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+			"integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+			"license": "MIT"
+		},
 		"node_modules/table": {
 			"version": "6.9.0",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
 			"integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"ajv": "^8.0.1",
@@ -22832,7 +24338,7 @@
 			"version": "8.17.1",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -22849,7 +24355,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/tailwind-merge": {
@@ -23118,12 +24624,6 @@
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
 			"dev": true
 		},
-		"node_modules/tiny-emitter": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-			"license": "MIT"
-		},
 		"node_modules/tiny-invariant": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -23225,7 +24725,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
+			"devOptional": true,
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
@@ -23389,6 +24889,15 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
+		"node_modules/tw-animate-css": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+			"integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Wombosvideo"
+			}
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -23519,7 +25028,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
+			"devOptional": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -23776,6 +25285,27 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/use-callback-ref": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+			"integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/use-memo-one": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
@@ -23783,6 +25313,28 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/use-sidecar": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+			"integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"detect-node-es": "^1.1.0",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/use-sync-external-store": {
@@ -23797,7 +25349,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/utils-merge": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 	"dependencies": {
 		"@google/genai": "^1.34.0",
 		"@tailwindcss/postcss": "^4.1.18",
+		"@wedevs/plugin-ui": "github:getdokan/plugin-ui",
 		"@wordpress/api-fetch": "^7.36.0",
 		"@wordpress/components": "^30.9.0",
 		"@wordpress/data": "^10.37.0",

--- a/src/admin/dashboard/App.tsx
+++ b/src/admin/dashboard/App.tsx
@@ -2,6 +2,7 @@ import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { withRouter } from '../../utils/router';
 import Layout from './Layout/Layout';
+import UpgradeBanner from './UpgradeBanner';
 import { createHashRouter, RouterProvider } from 'react-router-dom';
 import Settings from './pages/Settings';
 import Dashboard from './pages/Dashboard';
@@ -82,6 +83,7 @@ function App() {
 
 	return (
 		<>
+			<UpgradeBanner />
 			<RouterProvider router={ router } />
 		</>
 	);

--- a/src/admin/dashboard/TopBar.tsx
+++ b/src/admin/dashboard/TopBar.tsx
@@ -1,0 +1,173 @@
+import { applyFilters } from '@wordpress/hooks';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	Button,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+	TopBar as StorePulseTopBar,
+} from '@wedevs/plugin-ui';
+import {
+	BookOpen,
+	CircleHelp,
+	FileClock,
+	Lightbulb,
+	MessageCircleQuestion,
+} from 'lucide-react';
+import { CrownIcon, TryauraLogoWithText } from '../../components';
+import { hasPro } from '../../utils/tryaura';
+
+export type HelpMenuItem = {
+	id: string;
+	title: string;
+	url: string;
+	icon: React.ReactNode;
+};
+
+const getHelpMenuItems = ( isPro: boolean ): HelpMenuItem[] => {
+	const items: HelpMenuItem[] = [
+		{
+			id: 'documentation',
+			title: __( 'Documentation', 'tryaura' ),
+			url: 'https://storepulse.co/tryaura/docs/',
+			icon: <BookOpen />,
+		},
+		{
+			id: 'faq',
+			title: __( 'FAQ', 'tryaura' ),
+			url: 'https://storepulse.co/tryaura/#faq',
+			icon: <MessageCircleQuestion />,
+		},
+		{
+			id: 'request-a-feature',
+			title: __( 'Request a Feature', 'tryaura' ),
+			url: 'https://feedback.storepulse.co/',
+			icon: <Lightbulb />,
+		},
+		{
+			id: 'changelog',
+			title: __( 'Changelog', 'tryaura' ),
+			url: 'https://wordpress.org/plugins/tryaura/#developers',
+			icon: <FileClock />,
+		},
+	];
+
+	if ( ! isPro ) {
+		items.push( {
+			id: 'upgrade-to-pro',
+			title: __( 'Upgrade to Pro', 'tryaura' ),
+			url: 'https://storepulse.co/tryaura/pricing/',
+			icon: <CrownIcon />,
+		} );
+	}
+
+	/**
+	 * Filter the items shown in the admin Top Bar help menu.
+	 *
+	 * @param {HelpMenuItem[]} items Menu items ({ id, title, url, icon }).
+	 * @param {boolean}        isPro Whether TryAura Pro is active.
+	 */
+	return applyFilters(
+		'tryaura.admin.help_menu_items',
+		items,
+		isPro
+	) as HelpMenuItem[];
+};
+
+function TopBar() {
+	// @ts-ignore
+	const version: string = window?.tryAura?.version ?? '';
+	// @ts-ignore
+	const proVersion: string = window?.tryAura?.proVersion ?? '';
+	const isPro = hasPro();
+
+	const versions = [];
+	if ( version ) {
+		versions.push( {
+			// translators: %s: installed version of the free TryAura plugin.
+			version: sprintf( __( 'Lite v%s', 'tryaura' ), version ),
+			isPro: false,
+		} );
+	}
+	if ( isPro && proVersion ) {
+		versions.push( {
+			// translators: %s: installed version of the TryAura Pro plugin.
+			version: sprintf( __( 'Pro v%s', 'tryaura' ), proVersion ),
+			isPro: true,
+		} );
+	}
+
+	const helpMenuItems = getHelpMenuItems( isPro );
+
+	return (
+		<StorePulseTopBar
+			className="border-0 border-b border-solid border-border"
+			logo={
+				<a
+					href="https://storepulse.co/tryaura"
+					target="_blank"
+					rel="noopener noreferrer"
+					className="inline-block h-full"
+					aria-label={ __( 'TryAura website', 'tryaura' ) }
+				>
+					<TryauraLogoWithText className="h-full w-auto" />
+				</a>
+			}
+			versions={ versions }
+			rightSideComponents={
+				<>
+					<Button
+						variant="outline"
+						size="sm"
+						render={
+							// Base UI injects the button children into this anchor.
+							// eslint-disable-next-line jsx-a11y/anchor-has-content
+							<a
+								href="https://storepulse.co/contact/"
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						}
+					>
+						{ __( 'Get Support', 'tryaura' ) }
+					</Button>
+					<DropdownMenu>
+						<DropdownMenuTrigger
+							render={
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									aria-label={ __( 'Help menu', 'tryaura' ) }
+								/>
+							}
+						>
+							<CircleHelp />
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end">
+							{ helpMenuItems.map( ( item ) => (
+								<DropdownMenuItem
+									key={ item.id }
+									render={
+										// Base UI injects the item children into this anchor.
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a
+											href={ item.url }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									}
+								>
+									{ item.icon }
+									{ item.title }
+								</DropdownMenuItem>
+							) ) }
+						</DropdownMenuContent>
+					</DropdownMenu>
+				</>
+			}
+		/>
+	);
+}
+
+export default TopBar;

--- a/src/admin/dashboard/TopBar.tsx
+++ b/src/admin/dashboard/TopBar.tsx
@@ -137,12 +137,14 @@ function TopBar() {
 							render={
 								<Button
 									variant="ghost"
-									size="icon-sm"
+									size="icon"
 									aria-label={ __( 'Help menu', 'tryaura' ) }
 								/>
 							}
 						>
-							<CircleHelp />
+							{ /* size on the icon itself: plugin-ui's button styles
+							     the svg only when it has no `size-*` class. */ }
+							<CircleHelp className="size-6" />
 						</DropdownMenuTrigger>
 						<DropdownMenuContent align="end">
 							{ helpMenuItems.map( ( item ) => (

--- a/src/admin/dashboard/UpgradeBanner.tsx
+++ b/src/admin/dashboard/UpgradeBanner.tsx
@@ -1,0 +1,66 @@
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { X } from 'lucide-react';
+import {
+	getUpgradeToProUrl,
+	shouldShowUpgradeBanner,
+} from '../../utils/tryaura';
+
+/**
+ * Dismissible "Go Pro" promo banner shown on every dashboard route while
+ * TryAura Pro is not active. Visibility is decided server-side (per-user
+ * dismissal, re-shown after 30 days) and passed via localized data.
+ *
+ * @since PLUGIN_SINCE
+ */
+function UpgradeBanner() {
+	const [ visible, setVisible ] = useState( shouldShowUpgradeBanner() );
+
+	if ( ! visible ) {
+		return null;
+	}
+
+	const upgradeUrl = getUpgradeToProUrl();
+
+	const dismiss = () => {
+		// Hide immediately; persisting the dismissal is best-effort.
+		setVisible( false );
+		apiFetch( {
+			path: '/tryaura/v1/promotion/dismiss-banner',
+			method: 'POST',
+		} ).catch( () => {} );
+	};
+
+	return (
+		<div className="relative mb-6 rounded-lg bg-[#ffd932] px-6 py-5 text-black">
+			<button
+				type="button"
+				onClick={ dismiss }
+				aria-label={ __( 'Dismiss this banner', 'tryaura' ) }
+				className="absolute right-4 top-4 flex size-6 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0 text-black hover:bg-black/10"
+			>
+				<X className="size-4" />
+			</button>
+			<h2 className="m-0 pr-10 text-lg font-bold text-black">
+				{ __( 'Go Pro. Create Without Limits.', 'tryaura' ) }
+			</h2>
+			<p className="mb-4 mt-1 pr-10 text-sm text-black">
+				{ __(
+					'Unlock AI product videos, custom prompts, flexible image and video sizes, camera motion controls, and priority support.',
+					'tryaura'
+				) }
+			</p>
+			<a
+				href={ upgradeUrl }
+				target="_blank"
+				rel="noopener noreferrer"
+				className="inline-block rounded-md bg-black px-4 py-2 text-sm font-semibold text-white no-underline hover:bg-black/80 hover:text-white focus:text-white"
+			>
+				{ __( 'Upgrade Now', 'tryaura' ) }
+			</a>
+		</div>
+	);
+}
+
+export default UpgradeBanner;

--- a/src/admin/dashboard/index.tsx
+++ b/src/admin/dashboard/index.tsx
@@ -1,10 +1,23 @@
 import { createRoot } from '@wordpress/element';
 import domReady from '@wordpress/dom-ready';
+import { ThemeProvider } from '@wedevs/plugin-ui';
 import App from './App';
+import TopBar from './TopBar';
 import './style.scss';
 import menuFix from './utils/menu-fix.js';
 
 domReady( () => {
+	// The Top Bar mounts in its own root, outside the `.tryaura` Tailwind
+	// scope, so the plugin's importantized utilities can't reach plugin-ui.
+	const headerDomNode = document.getElementById( 'tryaura-admin-header' );
+	if ( headerDomNode ) {
+		createRoot( headerDomNode ).render(
+			<ThemeProvider pluginId="tryaura" storageKey={ false }>
+				<TopBar />
+			</ThemeProvider>
+		);
+	}
+
 	const dashboardDomNode = document.getElementById(
 		'tryaura-settings-root'
 	);

--- a/src/admin/dashboard/index.tsx
+++ b/src/admin/dashboard/index.tsx
@@ -4,6 +4,10 @@ import { ThemeProvider } from '@wedevs/plugin-ui';
 import App from './App';
 import TopBar from './TopBar';
 import './style.scss';
+// Own file (not part of style.scss): a second Tailwind compilation that
+// re-emits the Top Bar's utilities at ID specificity. See the comment inside.
+// Must be named style.css so wp-scripts merges it into style-index.css.
+import './topbar/style.css';
 import menuFix from './utils/menu-fix.js';
 
 domReady( () => {
@@ -18,9 +22,7 @@ domReady( () => {
 		);
 	}
 
-	const dashboardDomNode = document.getElementById(
-		'tryaura-settings-root'
-	);
+	const dashboardDomNode = document.getElementById( 'tryaura-settings-root' );
 	if ( dashboardDomNode ) {
 		const dashboardRoot = createRoot( dashboardDomNode! );
 		dashboardRoot.render( <App /> );

--- a/src/admin/dashboard/style.scss
+++ b/src/admin/dashboard/style.scss
@@ -1,4 +1,5 @@
 @import "../../base-tailwind.css";
+@import "@wedevs/plugin-ui/styles.css";
 
 @source "../dashboard/**/*.{ts,tsx,js,jsx,php,html}";
 
@@ -13,4 +14,41 @@
 	.components-modal__content {
 		padding: 0 !important;
 	}
+}
+
+/*
+ * The Top Bar help menu renders in a portal at body level, outside the
+ * `.tryaura` scope, so Tailwind utilities from this bundle can't reach it.
+ */
+/* Full-bleed the content area so the Top Bar spans the whole width, then
+   re-add the inset on the app body only (the header keeps its own padding). */
+.toplevel_page_tryaura #wpcontent {
+	padding: 0;
+	overflow-x: hidden;
+}
+
+.toplevel_page_tryaura #wpcontent .wrap {
+	margin: 0;
+}
+
+.toplevel_page_tryaura .tryaura-admin-page-body {
+	padding: 16px 20px 0;
+}
+
+/* Notices are captured into this hidden wrapper so the Top Bar sits first. */
+.tryaura-notice-list-hide {
+	display: none;
+}
+
+/* Doubled .pui-root + !important: Dokan's dokan-tailwind.css ships the same
+   plugin-ui utilities globally in wp-admin with !important at (0,2,0). */
+.pui-root.pui-root [data-slot="dropdown-menu-content"] {
+	width: max-content !important;
+	min-width: 13rem !important;
+}
+
+/* Keep wp-admin's global a:focus box-shadow out of the portal. */
+.pui-root.pui-root [data-slot="dropdown-menu-item"]:focus {
+	outline: none;
+	box-shadow: none;
 }

--- a/src/admin/dashboard/style.scss
+++ b/src/admin/dashboard/style.scss
@@ -2,6 +2,11 @@
 @import "@wedevs/plugin-ui/styles.css";
 
 @source "../dashboard/**/*.{ts,tsx,js,jsx,php,html}";
+/* Scan plugin-ui's compiled bundle so Tailwind generates the utility classes
+   its components use (e.g. the TopBar's h-7.5 / max-h-16.5). They aren't in
+   plugin-ui's own styles.css, so without this the bar breaks on any site that
+   doesn't separately ship those utilities (e.g. via Dokan's global CSS). */
+@source "../../../node_modules/@wedevs/plugin-ui/dist/index.js";
 
 
 .tryaura {

--- a/src/admin/dashboard/topbar/style.css
+++ b/src/admin/dashboard/topbar/style.css
@@ -1,0 +1,26 @@
+/* Standalone Tailwind compilation for the admin Top Bar (imported from
+   index.tsx, NOT from the dashboard style.scss — Tailwind only honors one utilities
+   emission per compilation, so this must be its own unit).
+
+   Why it exists: other plugin-ui consumers (dokan-pro, dokan-lite, wePOS, …)
+   ship plugin-ui's utilities globally in wp-admin scoped to
+   `:is(.pui-root, .dokan-layout)` — specificity (0,2,0) — sometimes from an
+   older plugin-ui build that lacks the Top Bar's responsive variants
+   (md:h-7.5, md:px-2, …). Their base utilities (p-0, h-10) then beat the
+   (0,1,0) copies in plugin-ui's styles.css at every viewport and squash the
+   version badges into oversized ovals. Re-emitting the utilities under the
+   header's ID — (1,1,0) + !important — makes the Top Bar win regardless of
+   what other plugins load. */
+@layer theme, base, components, utilities;
+
+@import "tailwindcss/theme.css" layer(theme);
+
+#tryaura-admin-header {
+  @import "tailwindcss/utilities.css" layer(utilities) important;
+}
+
+@source "../TopBar.tsx";
+/* The Top Bar is built from plugin-ui components, so their classes must be
+   scanned too. plugin-ui ships a single bundle, so this pulls in the full
+   plugin-ui utility set. */
+@source "../../../../node_modules/@wedevs/plugin-ui/dist/index.js";

--- a/src/utils/tryaura.ts
+++ b/src/utils/tryaura.ts
@@ -25,6 +25,13 @@ export const getUpgradeToProUrl = () => {
 	return upgradeToProUrl ?? '';
 };
 
+export const shouldShowUpgradeBanner = () => {
+	// Computed server-side: false when Pro is active, the banner was
+	// dismissed by this user less than 30 days ago, etc.
+	// @ts-ignore
+	return Boolean( window?.tryAura?.showUpgradeBanner );
+};
+
 export const getMediaSelectedItems = () => {
 	let frameObj =
 		wp?.media?.frame ||

--- a/tryaura.php
+++ b/tryaura.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:       TryAura: AI Virtual Try-On, Product Visualization & Product Videos for WooCommerce
- * Description:       TryAura is an AI-powered virtual try-on and content creation platform built for fashion and eCommerce. With seamless WooCommerce integration, it allows brands and shoppers to instantly visualize clothing on models, customers, or in any scene — without costly photoshoots. From product images to lifestyle videos, TryAura helps online stores boost engagement, reduce returns, and elevate their shopping experience with cutting-edge AI.
+ * Description:       Turn basic product photos into realistic photos, videos, and virtual try-ons that help WooCommerce shoppers buy with confidence.
  * Version:           1.0.4
  * Requires at least: 6.6
  * Requires PHP:      7.4


### PR DESCRIPTION
## What & why

Implements the persistent admin **Top Bar** from getdokan/tryaura-pro#40 (spec: getdokan/tryaura-pro#41). All TryAura admin screens now show the TryAura logo, Lite/Pro version badges, a **Get Support** button, and a **?** help menu — giving a consistent identity and one-click access to docs/support.

Built on the StorePulse component system (`@wedevs/plugin-ui`) so the same bar can later be shared with other StorePulse plugins (e.g. wePOS).

## How it works

- **Component** (`src/admin/dashboard/TopBar.tsx`): plugin-ui `TopBar` + `DropdownMenu`. Logo → storepulse.co/tryaura; badges are plain text (`Lite v1.0.4` / `Pro v1.0.1`, Pro only when active); five help links open in new tabs; Upgrade-to-Pro hidden for Pro users. Items are extensible via the `tryaura.admin.help_menu_items` JS filter.
- **Mount** (`src/admin/dashboard/index.tsx`): the bar renders into a dedicated `#tryaura-admin-header` root — **outside** the `.tryaura` Tailwind scope (whose importantized utilities would otherwise clobber plugin-ui) and **outside** `.wrap` (so it spans the full content width). Wrapped in plugin-ui `ThemeProvider` with default tokens.
- **PHP** (`inc/Admin/Admin.php`): localizes `version` / `hasPro` / `proVersion` read from the plugin file headers; a `.wp-header-end` notice-catcher (`admin_notices` at `-9999` / `PHP_INT_MAX`) hoists the bar above the WordPress admin notices, matching Dokan's dashboard behavior.
- **CSS** (`src/admin/dashboard/style.scss`): zeroes `#wpcontent` padding for full-bleed (re-inset on the app body only); dropdown width/focus overrides scoped to the plugin-ui portal.

Deliberately **out of scope** (agreed with product): custom indigo theme, dark mode, Shadow DOM — default plugin-ui tokens only.

## Fix: badges squashed into ovals when other plugins ship global plugin-ui utilities (cd1580e)

Testing the built ZIP on a second site surfaced a rendering bug: the version badges blew up into oversized ovals (40px tall, no padding) while the same build looked fine on the dev site.

**Root cause** — plugins like dokan-pro ship plugin-ui's Tailwind utilities globally in wp-admin, scoped to `:is(.pui-root, .dokan-layout)` — specificity (0,2,0) — sometimes generated from an **older plugin-ui build that lacks the Top Bar's responsive variants** (`md:h-7.5`, `md:px-2`, …). Their base utilities (`p-0`, `h-10`) then beat the (0,1,0) copies bundled in this PR at every viewport and squash the bar. The dev site only looked correct by luck: dokan-lite's newer sheet there happens to include the `md:` variants, so they won with the right values.

**Fix** — `src/admin/dashboard/topbar/style.css`: a standalone Tailwind compilation that re-emits the Top Bar's utilities under the `#tryaura-admin-header` ID — (1,1,0) + `!important` — so the bar wins regardless of what other plugins load. Two build-system constraints shaped it:

- Tailwind v4 honors only **one** utilities emission per compilation, so this can't live inside `style.scss` (a second import there silently emits nothing).
- `wp-scripts` only merges CSS files literally named `style.*` into the enqueued `style-index.css`, hence the `topbar/style.css` path (imported from `index.tsx`).

Trade-off: `style-index.css` grows ~515 KB → ~688 KB (one extra ID-scoped utility copy); it only loads on TryAura admin pages.

Verified on both sites: the broken install now measures identical to the reference (30px badge height, 2px/8px padding), help dropdown intact, dev site unchanged.

## Acceptance criteria — issue #40

- [x] Bar renders on all TryAura admin pages (Dashboard, Settings, future routes)
- [x] Logo links to storepulse.co/tryaura
- [x] Lite badge always shown (from free plugin header); Pro badge only when Pro active (from pro header); badges are plain text
- [x] Get Support → storepulse.co/contact/ in a new tab
- [x] **?** dropdown: Documentation, FAQ, Request a Feature, Changelog, Upgrade to Pro — correct order, new tabs
- [x] Upgrade to Pro hidden when Pro active
- [x] Dropdown closes on outside click and Escape (native to plugin-ui Base UI menu)
- [x] Responsive; sits below the WP admin bar

## Testing

Verified in-browser on a live WooCommerce install, both Pro-active and Lite-only:
badge states, all link URLs/targets, dropdown open/close (outside-click + Escape), full-bleed width (bar spans `#wpcontent` exactly), and bar hoisted above hidden notices. ESLint / PHPCS / production build all pass.

## Open decision for reviewers

The notice-catcher currently **hides all admin notices** on the TryAura page (Dokan parity). This is intentional and matches the reference, but it also suppresses core/error notices. Flagging so reviewers can confirm this is desired vs. relocating notices below the bar. See the self-review notes in the linked issue thread.

## Base branch

Targets `feat/wave3-apparel-cleanup` (not `main`) because the top-bar commit was built on top of that branch; this keeps the PR diff to the top-bar changes only. Re-target to `main` once Wave 3 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5bM5ACrcGFwvVo6jEyVKF
