### PR TITLE
feat: add Pro promotion touchpoints — promo banner, sidebar Upgrade button, plugins screen updates

### DIFF
--- a/inc/Admin/Admin.php
+++ b/inc/Admin/Admin.php
@@ -2,6 +2,7 @@
 
 namespace Dokan\TryAura\Admin;
 
+use Dokan\TryAura\Admin\Promotion;
 use Dokan\TryAura\TryAura;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -36,6 +37,30 @@ class Admin {
 		// Capture admin notices so the Top Bar renders first on our page.
 		add_action( 'admin_notices', array( $this, 'inject_before_notices' ), -9999 );
 		add_action( 'admin_notices', array( $this, 'inject_after_notices' ), PHP_INT_MAX );
+
+		add_filter( 'plugin_action_links_' . plugin_basename( TRYAURA_FILE ), array( $this, 'add_settings_action_link' ) );
+	}
+
+	/**
+	 * Add the "Settings" action link on the All Plugins screen.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @param array $links Existing plugin action links.
+	 *
+	 * @return array
+	 */
+	public function add_settings_action_link( array $links ): array {
+		array_unshift(
+			$links,
+			sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( admin_url( 'admin.php?page=tryaura#/settings' ) ),
+				esc_html__( 'Settings', 'tryaura' )
+			)
+		);
+
+		return $links;
 	}
 
 	/**
@@ -217,6 +242,8 @@ class Admin {
 				'version'                  => $this->get_plugin_version( TRYAURA_FILE ),
 				'hasPro'                   => (bool) TryAura::is_pro_exists(),
 				'proVersion'               => TryAura::is_pro_exists() && defined( 'TRYAURAPRO_FILE' ) ? $this->get_plugin_version( TRYAURAPRO_FILE ) : '',
+				'upgradeToProUrl'          => Promotion::UPGRADE_URL,
+				'showUpgradeBanner'        => Promotion::should_show_upgrade_banner(),
 				/**
 				 * Controls whether the Gemini API settings page is read-only.
 				 *

--- a/inc/Admin/Promotion.php
+++ b/inc/Admin/Promotion.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Dokan\TryAura\Admin;
+
+use Dokan\TryAura\TryAura;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Pro promotion touchpoints shown while TryAura Pro is not active.
+ *
+ * Adds the "Upgrade" button to the TryAura admin sidebar menu and the
+ * "Upgrade to Pro" action link on the All Plugins screen. The dashboard
+ * promo banner is rendered by the admin SPA; its visibility is computed
+ * here (see should_show_upgrade_banner()).
+ *
+ * @since PLUGIN_SINCE
+ */
+class Promotion {
+	/**
+	 * User meta key storing the promo banner dismissal timestamp.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @var string
+	 */
+	const BANNER_DISMISSED_META_KEY = '_tryaura_promo_banner_dismissed_at';
+
+	/**
+	 * How long a banner dismissal lasts before the banner re-appears.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @var int
+	 */
+	const BANNER_DISMISSAL_DURATION = 30 * DAY_IN_SECONDS;
+
+	/**
+	 * Upgrade/pricing page URL.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @var string
+	 */
+	const UPGRADE_URL = 'https://storepulse.co/tryaura/pricing/';
+
+	/**
+	 * Bootstrap promotion hooks. All output is gated on Pro being absent.
+	 *
+	 * @since PLUGIN_SINCE
+	 */
+	public function __construct() {
+		if ( TryAura::is_pro_exists() ) {
+			return;
+		}
+
+		// After Admin::register_admin_page() (default priority) so the
+		// Upgrade entry lands after Dashboard and Settings.
+		add_action( 'admin_menu', array( $this, 'register_upgrade_menu' ), 20 );
+		add_action( 'admin_print_styles', array( $this, 'print_upgrade_menu_styles' ) );
+		add_action( 'admin_print_footer_scripts', array( $this, 'print_upgrade_menu_script' ) );
+
+		add_filter( 'plugin_action_links_' . plugin_basename( TRYAURA_FILE ), array( $this, 'add_upgrade_action_link' ) );
+	}
+
+	/**
+	 * Whether the promo banner should render for the current user.
+	 *
+	 * True when Pro is absent and the user has never dismissed the banner,
+	 * or the last dismissal is older than 30 days.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @return bool
+	 */
+	public static function should_show_upgrade_banner(): bool {
+		if ( TryAura::is_pro_exists() ) {
+			return false;
+		}
+
+		$dismissed_at = (int) get_user_meta( get_current_user_id(), self::BANNER_DISMISSED_META_KEY, true );
+
+		if ( ! $dismissed_at ) {
+			return true;
+		}
+
+		return ( time() - $dismissed_at ) > self::BANNER_DISMISSAL_DURATION;
+	}
+
+	/**
+	 * Append the "Upgrade" entry to the TryAura admin submenu.
+	 *
+	 * WordPress links submenu slugs starting with http(s) directly, so the
+	 * entry points straight at the pricing page.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @return void
+	 */
+	public function register_upgrade_menu(): void {
+		global $submenu;
+
+		if ( ! current_user_can( 'manage_options' ) || ! isset( $submenu['tryaura'] ) ) {
+			return;
+		}
+
+		$submenu['tryaura'][] = array( // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			__( 'Upgrade', 'tryaura' ),
+			'manage_options',
+			self::UPGRADE_URL,
+		);
+	}
+
+	/**
+	 * Style the sidebar Upgrade entry as a filled button.
+	 *
+	 * Printed on every admin page because the sidebar menu is global.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @return void
+	 */
+	public function print_upgrade_menu_styles(): void {
+		$selector = $this->upgrade_menu_selector();
+		?>
+		<style id="tryaura-upgrade-menu-style">
+			<?php echo $selector; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> {
+				display: inline-block;
+				margin: 4px 0 4px 10px;
+				padding: 4px 14px;
+				background: #ffd932;
+				color: #000000;
+				border-radius: 4px;
+				font-weight: 600;
+			}
+			<?php echo $selector; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>:hover,
+			<?php echo $selector; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>:focus {
+				background: #ffe164;
+				color: #000000;
+				box-shadow: none;
+			}
+		</style>
+		<?php
+	}
+
+	/**
+	 * CSS selector matching the sidebar Upgrade menu link.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @return string
+	 */
+	private function upgrade_menu_selector(): string {
+		return '#adminmenu #toplevel_page_tryaura .wp-submenu a[href^="' . esc_url( self::UPGRADE_URL ) . '"]';
+	}
+
+	/**
+	 * Open the sidebar Upgrade link in a new tab.
+	 *
+	 * Submenu entries render as plain anchors, so the target attribute has
+	 * to be added client-side (same approach as Elementor).
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @return void
+	 */
+	public function print_upgrade_menu_script(): void {
+		?>
+		<script id="tryaura-upgrade-menu-script">
+			document
+				.querySelectorAll( '<?php echo $this->upgrade_menu_selector(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>' )
+				.forEach( function ( link ) {
+					link.setAttribute( 'target', '_blank' );
+					link.setAttribute( 'rel', 'noopener noreferrer' );
+				} );
+		</script>
+		<?php
+	}
+
+	/**
+	 * Add the "Upgrade to Pro" action link on the All Plugins screen.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @param array $links Existing plugin action links.
+	 *
+	 * @return array
+	 */
+	public function add_upgrade_action_link( array $links ): array {
+		$links[] = sprintf(
+			'<a href="%s" target="_blank" rel="noopener noreferrer" style="color:#FF8C00;font-weight:700;">%s</a>',
+			esc_url( self::UPGRADE_URL ),
+			esc_html__( 'Upgrade to Pro', 'tryaura' )
+		);
+
+		return $links;
+	}
+}

--- a/inc/DependencyManagement/Providers/AdminServiceProvider.php
+++ b/inc/DependencyManagement/Providers/AdminServiceProvider.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use Dokan\TryAura\DependencyManagement\BaseServiceProvider;
 use Dokan\TryAura\Admin\Admin;
 use Dokan\TryAura\Admin\Enhancer;
+use Dokan\TryAura\Admin\Promotion;
 
 /**
  * AdminServiceProvider Class
@@ -25,8 +26,9 @@ class AdminServiceProvider extends BaseServiceProvider {
 	 * @var array
 	 */
 	protected $services = [
-		'admin'    => Admin::class,
-		'enhancer' => Enhancer::class,
+		'admin'     => Admin::class,
+		'enhancer'  => Enhancer::class,
+		'promotion' => Promotion::class,
 	];
 
 	/**

--- a/inc/DependencyManagement/Providers/RestServiceProvider.php
+++ b/inc/DependencyManagement/Providers/RestServiceProvider.php
@@ -12,6 +12,7 @@ use Dokan\TryAura\Rest\GenerateController;
 use Dokan\TryAura\Rest\DashboardController;
 use Dokan\TryAura\Rest\VideoThumbnailController;
 use Dokan\TryAura\Rest\ProductController;
+use Dokan\TryAura\Rest\PromotionController;
 
 /**
  * RestServiceProvider Class
@@ -33,6 +34,7 @@ class RestServiceProvider extends BaseServiceProvider {
 		'dashboard_controller'       => DashboardController::class,
 		'video_thumbnail_controller' => VideoThumbnailController::class,
 		'product_controller'         => ProductController::class,
+		'promotion_controller'       => PromotionController::class,
 	];
 
 	/**

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -98,6 +98,9 @@ class Plugin {
 		if ( $this->container->has( 'product_controller' ) ) {
 			$this->container->get( 'product_controller' );
 		}
+		if ( $this->container->has( 'promotion_controller' ) ) {
+			$this->container->get( 'promotion_controller' );
+		}
 
 		// Register assets.
 		if ( $this->container->has( 'assets' ) ) {
@@ -130,6 +133,10 @@ class Plugin {
 			}
 			if ( $this->container->has( 'admin_product_video' ) ) {
 				$this->container->get( 'admin_product_video' );
+			}
+			// Pro promotion touchpoints (sidebar Upgrade button, plugins screen link).
+			if ( $this->container->has( 'promotion' ) ) {
+				$this->container->get( 'promotion' );
 			}
 		}
 

--- a/inc/Rest/PromotionController.php
+++ b/inc/Rest/PromotionController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Dokan\TryAura\Rest;
+
+use Dokan\TryAura\Admin\Promotion;
+use WP_REST_Response;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * REST controller for Pro promotion state (promo banner dismissal).
+ *
+ * @since PLUGIN_SINCE
+ */
+class PromotionController {
+	/**
+	 * REST API namespace.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @var string api namespace.
+	 */
+	protected string $namespace = 'tryaura/v1';
+
+	/**
+	 * REST API base.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @var string rest base.
+	 */
+	protected string $rest_base = 'promotion';
+
+	/**
+	 * Class constructor.
+	 *
+	 * @since PLUGIN_SINCE
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register REST routes.
+	 *
+	 * @since PLUGIN_SINCE
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/dismiss-banner',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'dismiss_banner' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Simple permissions check: only admins (manage_options).
+	 *
+	 * @since PLUGIN_SINCE
+	 */
+	public function permissions_check(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Record the promo banner dismissal for the current user.
+	 *
+	 * Stores a timestamp so the banner can re-appear after the dismissal
+	 * duration (30 days) elapses.
+	 *
+	 * @since PLUGIN_SINCE
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function dismiss_banner(): WP_REST_Response {
+		update_user_meta( get_current_user_id(), Promotion::BANNER_DISMISSED_META_KEY, time() );
+
+		return new WP_REST_Response( array( 'dismissed' => true ) );
+	}
+}

--- a/src/admin/dashboard/App.tsx
+++ b/src/admin/dashboard/App.tsx
@@ -2,6 +2,7 @@ import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { withRouter } from '../../utils/router';
 import Layout from './Layout/Layout';
+import UpgradeBanner from './UpgradeBanner';
 import { createHashRouter, RouterProvider } from 'react-router-dom';
 import Settings from './pages/Settings';
 import Dashboard from './pages/Dashboard';
@@ -82,6 +83,7 @@ function App() {
 
 	return (
 		<>
+			<UpgradeBanner />
 			<RouterProvider router={ router } />
 		</>
 	);

--- a/src/admin/dashboard/UpgradeBanner.tsx
+++ b/src/admin/dashboard/UpgradeBanner.tsx
@@ -1,0 +1,66 @@
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { X } from 'lucide-react';
+import {
+	getUpgradeToProUrl,
+	shouldShowUpgradeBanner,
+} from '../../utils/tryaura';
+
+/**
+ * Dismissible "Go Pro" promo banner shown on every dashboard route while
+ * TryAura Pro is not active. Visibility is decided server-side (per-user
+ * dismissal, re-shown after 30 days) and passed via localized data.
+ *
+ * @since PLUGIN_SINCE
+ */
+function UpgradeBanner() {
+	const [ visible, setVisible ] = useState( shouldShowUpgradeBanner() );
+
+	if ( ! visible ) {
+		return null;
+	}
+
+	const upgradeUrl = getUpgradeToProUrl();
+
+	const dismiss = () => {
+		// Hide immediately; persisting the dismissal is best-effort.
+		setVisible( false );
+		apiFetch( {
+			path: '/tryaura/v1/promotion/dismiss-banner',
+			method: 'POST',
+		} ).catch( () => {} );
+	};
+
+	return (
+		<div className="relative mb-6 rounded-lg bg-[#ffd932] px-6 py-5 text-black">
+			<button
+				type="button"
+				onClick={ dismiss }
+				aria-label={ __( 'Dismiss this banner', 'tryaura' ) }
+				className="absolute right-4 top-4 flex size-6 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0 text-black hover:bg-black/10"
+			>
+				<X className="size-4" />
+			</button>
+			<h2 className="m-0 pr-10 text-lg font-bold text-black">
+				{ __( 'Go Pro. Create Without Limits.', 'tryaura' ) }
+			</h2>
+			<p className="mb-4 mt-1 pr-10 text-sm text-black">
+				{ __(
+					'Unlock AI product videos, custom prompts, flexible image and video sizes, camera motion controls, and priority support.',
+					'tryaura'
+				) }
+			</p>
+			<a
+				href={ upgradeUrl }
+				target="_blank"
+				rel="noopener noreferrer"
+				className="inline-block rounded-md bg-black px-4 py-2 text-sm font-semibold text-white no-underline hover:bg-black/80 hover:text-white focus:text-white"
+			>
+				{ __( 'Upgrade Now', 'tryaura' ) }
+			</a>
+		</div>
+	);
+}
+
+export default UpgradeBanner;

--- a/src/utils/tryaura.ts
+++ b/src/utils/tryaura.ts
@@ -25,6 +25,13 @@ export const getUpgradeToProUrl = () => {
 	return upgradeToProUrl ?? '';
 };
 
+export const shouldShowUpgradeBanner = () => {
+	// Computed server-side: false when Pro is active, the banner was
+	// dismissed by this user less than 30 days ago, etc.
+	// @ts-ignore
+	return Boolean( window?.tryAura?.showUpgradeBanner );
+};
+
 export const getMediaSelectedItems = () => {
 	let frameObj =
 		wp?.media?.frame ||

--- a/tryaura.php
+++ b/tryaura.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:       TryAura: AI Virtual Try-On, Product Visualization & Product Videos for WooCommerce
- * Description:       TryAura is an AI-powered virtual try-on and content creation platform built for fashion and eCommerce. With seamless WooCommerce integration, it allows brands and shoppers to instantly visualize clothing on models, customers, or in any scene — without costly photoshoots. From product images to lifestyle videos, TryAura helps online stores boost engagement, reduce returns, and elevate their shopping experience with cutting-edge AI.
+ * Description:       Turn basic product photos into realistic photos, videos, and virtual try-ons that help WooCommerce shoppers buy with confidence.
  * Version:           1.0.4
  * Requires at least: 6.6
  * Requires PHP:      7.4


### PR DESCRIPTION
## Summary

Implements the three Pro-upsell touchpoints from getdokan/tryaura-pro#42 ([spec](https://github.com/getdokan/tryaura-pro/issues/42#issuecomment-5054729450)), all shown only while TryAura Pro is not active:

- **Promo banner** — dismissible "Go Pro. Create Without Limits." card on every dashboard SPA route, below the Top Bar. `#ffd932` background, black text, black "Upgrade Now" CTA (new tab). Dismissal is stored per user as a timestamp in user meta via a new `POST tryaura/v1/promotion/dismiss-banner` endpoint; the banner re-appears 30 days after dismissal (PM decision). The show/hide decision is computed server-side and localized, so there is no flash on load.
- **Sidebar Upgrade button** — "Upgrade" submenu entry under the TryAura admin menu, styled as a filled `#ffd932` button; a small footer script sets `target="_blank"` (Elementor approach).
- **All Plugins screen** — new "Settings" action link (default styling, always shown) and a bold `#FF8C00` "Upgrade to Pro" link (new tab, Pro-gated); plugin header description shortened to the approved marketing copy.

New `Promotion` admin service and `PromotionController` REST controller are wired through the existing service-container providers. New symbols use `@since PLUGIN_SINCE`.

## Test plan

Verified end-to-end in Chrome on a local site (plus wp-cli for time-travel):

- [x] Banner renders on Dashboard and Settings routes with exact spec copy/colors; CTA opens pricing in a new tab
- [x] Dismiss X hides the banner, persists the per-user timestamp via REST, and the banner stays hidden across reloads
- [x] Banner re-shows when the stored dismissal is older than 30 days (simulated)
- [x] Sidebar Upgrade button opens pricing in a new tab; hidden when Pro is active
- [x] Plugins screen shows "Settings | Deactivate | Upgrade to Pro" and the shortened description; the Upgrade link disappears when Pro is active while Settings remains
- [x] With TryAura Pro active, all three touchpoints are gone
- [x] PHPCS clean on changed files (matching repo conventions); production build passes

Closes getdokan/tryaura-pro#42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UL9nyXmJTkPB7QmT7jTKGF