### PR TITLE
chore: bump free plugin version to 2.0.0

### DIFF
--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -22,7 +22,7 @@ class Plugin {
 	 *
 	 * @var string
 	 */
-	private $version = '1.0.4';
+	private $version = '2.0.0';
 	private Container $container;
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tryaura",
-	"version": "1.0.4",
+	"version": "2.0.0",
 	"description": "an AI-powered virtual try-on and content creation platform built for fashion and eCommerce.",
 	"private": true,
 	"main": "index.js",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 6.6
 Tested up to: 6.9.4
 WC tested up to: 10.7.0
 Requires PHP: 7.4
-Stable tag: 1.0.4
+Stable tag: 2.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tryaura.php
+++ b/tryaura.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       TryAura: AI Virtual Try-On, Product Visualization & Product Videos for WooCommerce
  * Description:       Turn basic product photos into realistic photos, videos, and virtual try-ons that help WooCommerce shoppers buy with confidence.
- * Version:           1.0.4
+ * Version:           2.0.0
  * Requires at least: 6.6
  * Requires PHP:      7.4
  * Author:            weDevs


### PR DESCRIPTION
### Closes

* Closes getdokan/plugin-internal-tasks#2189

## Summary
Bumps the TryAura free plugin version to **2.0.0** ahead of release. Branched from `fix/16-post-gemini-bugfixes`.

Updates the version in all four canonical spots:

| File | Field |
|---|---|
| `package.json` | `version` (source of truth) |
| `tryaura.php` | plugin header `Version:` |
| `inc/Plugin.php` | `private $version` |
| `readme.txt` | `Stable tag` |

## Left to the release pipeline (intentionally not touched)
- **`@since PLUGIN_SINCE`** placeholders — replaced with the version by `npm run version` (`bin/version-replace.js`) at build.
- **`languages/tryaura.pot`** header — regenerated from the plugin header by `npm run makepot`.
- The `'1.0.0'` literals in `inc/Common/Assets.php` / `inc/WooCommerce/WooCommerce.php` are per-asset cache-busting fallbacks (overridden by the webpack build hash), **not** the plugin version.

## Notes / follow-ups
- `bin/make-zip.js` only syncs `public $version`, but the property is `private $version` — so `inc/Plugin.php` was bumped manually here. Worth aligning the regex (or the property visibility) so future releases auto-sync.
- `readme.txt` `Stable tag` now points at 2.0.0 with no matching `= v2.0.0 =` changelog section yet — add one before the wp.org push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UL9nyXmJTkPB7QmT7jTKGF
